### PR TITLE
Additional regex params needed for message validation

### DIFF
--- a/reasoner_pydantic/kgraph.py
+++ b/reasoner_pydantic/kgraph.py
@@ -4,7 +4,7 @@ from typing import List, Union
 
 from pydantic import BaseModel, constr, Field
 
-#CURIE = constr(regex='^.+:.+$')
+# CURIE = constr(regex='^.+:.+$')
 CURIE = constr(regex="^.+.+$|^{?([0-9a-fA-F]){8}(-([0-9a-fA-F]){4}){3}-([0-9a-fA-F]){12}}?$")
 
 

--- a/reasoner_pydantic/kgraph.py
+++ b/reasoner_pydantic/kgraph.py
@@ -4,7 +4,8 @@ from typing import List, Union
 
 from pydantic import BaseModel, constr, Field
 
-CURIE = constr(regex='^.+:.+$')
+#CURIE = constr(regex='^.+:.+$')
+CURIE = constr(regex="^.+.+$|^{?([0-9a-fA-F]){8}(-([0-9a-fA-F]){4}){3}-([0-9a-fA-F]){12}}?$")
 
 
 class KNode(BaseModel):

--- a/reasoner_pydantic/qgraph.py
+++ b/reasoner_pydantic/qgraph.py
@@ -4,7 +4,8 @@ from typing import List, Union
 
 from pydantic import BaseModel, constr, Field
 
-CURIE = constr(regex='^.+:.+$')
+# CURIE = constr(regex='^.+:.+$')
+CURIE = constr(regex='^.+.+$|\A\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\}\z')
 
 
 class QNode(BaseModel):

--- a/reasoner_pydantic/qgraph.py
+++ b/reasoner_pydantic/qgraph.py
@@ -1,11 +1,11 @@
 # pylint: disable=too-few-public-methods, missing-class-docstring
 """Query graph models."""
 from typing import List, Union
-
+import re
 from pydantic import BaseModel, constr, Field
 
 # CURIE = constr(regex='^.+:.+$')
-CURIE = constr(regex='^.+.+$|\A\{[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\}\z')
+CURIE = constr(regex="^.+.+$|^{?([0-9a-fA-F]){8}(-([0-9a-fA-F]){4}){3}-([0-9a-fA-F]){12}}?$")
 
 
 class QNode(BaseModel):

--- a/reasoner_pydantic/qgraph.py
+++ b/reasoner_pydantic/qgraph.py
@@ -1,7 +1,6 @@
 # pylint: disable=too-few-public-methods, missing-class-docstring
 """Query graph models."""
 from typing import List, Union
-import re
 from pydantic import BaseModel, constr, Field
 
 # CURIE = constr(regex='^.+:.+$')

--- a/reasoner_pydantic/results.py
+++ b/reasoner_pydantic/results.py
@@ -4,7 +4,8 @@ from typing import Dict, List, Union
 
 from pydantic import BaseModel, constr, Field
 
-CURIE = constr(regex='^.+:.+$')
+# CURIE = constr(regex='^.+:.+$')
+CURIE = constr(regex="^.+.+$|^{?([0-9a-fA-F]){8}(-([0-9a-fA-F]){4}){3}-([0-9a-fA-F]){12}}?$")
 
 
 class EdgeBinding(BaseModel):


### PR DESCRIPTION
there were node ids in the kg and qg pydantic definitions that were of type GUID . these was causing a validation errors.

the solution present here appends the regex for GUIDs onto the existing regex for CURIES.