### PR TITLE
Hashable Models

### DIFF
--- a/reasoner_pydantic/base_model.py
+++ b/reasoner_pydantic/base_model.py
@@ -1,6 +1,10 @@
-import collections
-
 from pydantic import BaseModel as PydanticBaseModel
 
 class BaseModel(PydanticBaseModel):
     """ Custom base model for all classes """
+
+    def __hash__(self) -> int:
+        """ Hash function based on Pydantic implementation """
+        # if hasattr(self, "__root__"):
+        #     return hash(self.__root__)
+        return hash(self.__class__) + hash(tuple(self.__dict__.values()))

--- a/reasoner_pydantic/base_model.py
+++ b/reasoner_pydantic/base_model.py
@@ -19,7 +19,8 @@ class BaseModel(PydanticBaseModel):
     def __hash__(self) -> int:
         """ Hash function based on Pydantic implementation """
         if not self._hash:
-            self._hash = hash(self.__class__) + hash(tuple(self.__dict__.values()))
+            self._hash = hash(
+                (self.__class__, tuple(self.__dict__.values())))
         return self._hash
 
     def __setattr__(self, name, value):

--- a/reasoner_pydantic/base_model.py
+++ b/reasoner_pydantic/base_model.py
@@ -1,10 +1,48 @@
-from pydantic import BaseModel as PydanticBaseModel
+from typing import Callable
+import weakref
+from pydantic import BaseModel as PydanticBaseModel, PrivateAttr
 
 class BaseModel(PydanticBaseModel):
-    """ Custom base model for all classes """
+    """
+    Custom base model for all classes
+
+    This provides a hash function that assumes all fields are either:
+
+    1. Immutable
+    2. Derived from BaseModel
+    3. Able to call a hash invalidation hook on their own
+    """
+
+    _hash: int = PrivateAttr(default=None)
+    _invalidate_hook: Callable = PrivateAttr(default=None)
 
     def __hash__(self) -> int:
         """ Hash function based on Pydantic implementation """
-        # if hasattr(self, "__root__"):
-        #     return hash(self.__root__)
-        return hash(self.__class__) + hash(tuple(self.__dict__.values()))
+        if not self._hash:
+            self._hash = hash(self.__class__) + hash(tuple(self.__dict__.values()))
+        return self._hash
+
+    def __setattr__(self, name, value):
+        """ Custom setattr that invalidates hash """
+
+        if name != "_hash":
+            self.invalidate_hash()
+        return super().__setattr__(name, value)
+
+    def invalidate_hash(self):
+        """ Invalidate stored hash value """
+        self._hash = None
+        # Propogate
+        if self._invalidate_hook:
+            self._invalidate_hook()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.__custom_root_type__:
+            return
+
+        # Look for BaseModel fields and give them a hook
+        # that they can use to invalidate hash on this object
+        for value in self.__dict__.values():
+            if hasattr(value, "_invalidate_hook"):
+                value._invalidate_hook = self.invalidate_hash

--- a/reasoner_pydantic/base_model.py
+++ b/reasoner_pydantic/base_model.py
@@ -1,0 +1,6 @@
+import collections
+
+from pydantic import BaseModel as PydanticBaseModel
+
+class BaseModel(PydanticBaseModel):
+    """ Custom base model for all classes """

--- a/reasoner_pydantic/kgraph.py
+++ b/reasoner_pydantic/kgraph.py
@@ -1,9 +1,10 @@
 """Knowledge graph models."""
 from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from .shared import Attribute, BiolinkEntity, BiolinkPredicate, CURIE
+from .base_model import BaseModel
 
 
 class Node(BaseModel):

--- a/reasoner_pydantic/kgraph.py
+++ b/reasoner_pydantic/kgraph.py
@@ -1,22 +1,23 @@
 """Knowledge graph models."""
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
 from pydantic import Field
 
 from .shared import Attribute, BiolinkEntity, BiolinkPredicate, CURIE
 from .base_model import BaseModel
+from .utils import HashableMapping, HashableSequence
 
 
 class Node(BaseModel):
     """Knowledge graph node."""
 
-    categories: Optional[List[BiolinkEntity]] = Field(
+    categories: Optional[HashableSequence[BiolinkEntity]] = Field(
         None,
         title='categories',
         nullable=True,
     )
     name: Optional[str] = Field(None, nullable=True)
-    attributes: Optional[List[Attribute]] = Field(None, nullable=True)
+    attributes: Optional[HashableSequence[Attribute]] = Field(None, nullable=True)
 
     class Config:
         title = 'knowledge-graph node'
@@ -41,7 +42,7 @@ class Edge(BaseModel):
         title='object node id',
     )
     predicate: Optional[BiolinkPredicate] = Field(None, nullable=True)
-    attributes: Optional[List[Attribute]] = Field(None, nullable=True)
+    attributes: Optional[HashableSequence[Attribute]] = Field(None, nullable=True)
 
     class Config:
         title = 'knowledge-graph edge'
@@ -51,11 +52,11 @@ class Edge(BaseModel):
 class KnowledgeGraph(BaseModel):
     """Knowledge graph."""
 
-    nodes: Dict[str, Node] = Field(
+    nodes: HashableMapping[str, Node] = Field(
         ...,
         title='nodes',
     )
-    edges: Dict[str, Edge] = Field(
+    edges: HashableMapping[str, Edge] = Field(
         ...,
         title='edges',
     )

--- a/reasoner_pydantic/message.py
+++ b/reasoner_pydantic/message.py
@@ -1,9 +1,10 @@
 """Reasoner API models."""
-from typing import List, Optional
+from typing import  Optional
 
 from pydantic import constr, Field
 
 from .base_model import BaseModel
+from .utils import HashableSequence
 from .results import Result
 from .qgraph import QueryGraph
 from .kgraph import KnowledgeGraph
@@ -24,7 +25,7 @@ class Message(BaseModel):
         title='knowledge graph',
         nullable=True,
     )
-    results: Optional[List[Result]] = Field(
+    results: Optional[HashableSequence[Result]] = Field(
         None,
         title='list of results',
         nullable=True,
@@ -88,7 +89,7 @@ class Response(BaseModel):
         title='message',
     )
 
-    logs: Optional[List[LogEntry]] = Field(None, nullable=True)
+    logs: Optional[HashableSequence[LogEntry]] = Field(None, nullable=True)
 
     status: Optional[str] = Field(None, nullable=True)
 

--- a/reasoner_pydantic/message.py
+++ b/reasoner_pydantic/message.py
@@ -1,8 +1,9 @@
 """Reasoner API models."""
 from typing import List, Optional
 
-from pydantic import BaseModel, constr, Field
+from pydantic import constr, Field
 
+from .base_model import BaseModel
 from .results import Result
 from .qgraph import QueryGraph
 from .kgraph import KnowledgeGraph

--- a/reasoner_pydantic/metakg.py
+++ b/reasoner_pydantic/metakg.py
@@ -1,23 +1,24 @@
 from reasoner_pydantic.shared import CURIE
-from typing import Dict, List, Optional
+from typing import Optional
 
 from pydantic import conlist
 from reasoner_pydantic import BiolinkEntity, BiolinkPredicate
 
 from .base_model import BaseModel
+from .utils import HashableMapping, HashableSequence
 
 class MetaAttribute(BaseModel):
     """MetaAttribute."""
     attribute_type_id: CURIE
     attribute_source: Optional[str]
-    original_attribute_names: Optional[List[str]]
+    original_attribute_names: Optional[HashableSequence[str]]
     constraint_use: Optional[bool] = False
     constraint_name: Optional[str]
 
 
 class MetaNode(BaseModel):
     id_prefixes: conlist(str, min_items=1)
-    attributes: Optional[List[MetaAttribute]]
+    attributes: Optional[HashableSequence[MetaAttribute]]
 
     class Config:
         extra = 'forbid'
@@ -27,12 +28,12 @@ class MetaEdge(BaseModel):
     subject: BiolinkEntity
     predicate: BiolinkPredicate
     object: BiolinkEntity
-    attributes: Optional[List[MetaAttribute]]
+    attributes: Optional[HashableSequence[MetaAttribute]]
 
     class Config:
         extra = 'forbid'
 
 
 class MetaKnowledgeGraph(BaseModel):
-    nodes: Dict[str, MetaNode]
-    edges: List[MetaEdge]
+    nodes: HashableMapping[str, MetaNode]
+    edges: HashableSequence[MetaEdge]

--- a/reasoner_pydantic/metakg.py
+++ b/reasoner_pydantic/metakg.py
@@ -1,9 +1,10 @@
 from reasoner_pydantic.shared import CURIE
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, conlist
+from pydantic import conlist
 from reasoner_pydantic import BiolinkEntity, BiolinkPredicate
 
+from .base_model import BaseModel
 
 class MetaAttribute(BaseModel):
     """MetaAttribute."""

--- a/reasoner_pydantic/metakg.py
+++ b/reasoner_pydantic/metakg.py
@@ -1,11 +1,11 @@
+from pydantic import validator
 from reasoner_pydantic.shared import CURIE
 from typing import Optional
 
-from pydantic import conlist
 from reasoner_pydantic import BiolinkEntity, BiolinkPredicate
 
 from .base_model import BaseModel
-from .utils import HashableMapping, HashableSequence
+from .utils import HashableMapping, HashableSequence, nonzero_validator
 
 class MetaAttribute(BaseModel):
     """MetaAttribute."""
@@ -17,7 +17,9 @@ class MetaAttribute(BaseModel):
 
 
 class MetaNode(BaseModel):
-    id_prefixes: conlist(str, min_items=1)
+    id_prefixes: HashableSequence[str]
+    _nonzero_id_prefixes = \
+        validator('id_prefixes', allow_reuse=True)(nonzero_validator)
     attributes: Optional[HashableSequence[MetaAttribute]]
 
     class Config:

--- a/reasoner_pydantic/qgraph.py
+++ b/reasoner_pydantic/qgraph.py
@@ -6,7 +6,6 @@ from reasoner_pydantic.utils import HashableMapping
 from typing import Any, Optional, Union
 
 from pydantic import Field
-from pydantic.types import conlist
 
 from .base_model import BaseModel
 from .utils import HashableMapping, HashableSequence, nonzero_validator

--- a/reasoner_pydantic/qgraph.py
+++ b/reasoner_pydantic/qgraph.py
@@ -2,9 +2,10 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 from pydantic.types import conlist
 
+from .base_model import BaseModel
 from .shared import BiolinkEntity, BiolinkPredicate, CURIE
 
 

--- a/reasoner_pydantic/qgraph.py
+++ b/reasoner_pydantic/qgraph.py
@@ -1,11 +1,13 @@
 """Query graph models."""
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from reasoner_pydantic.utils import HashableMapping
+from typing import Any, Optional, Union
 
 from pydantic import Field
 from pydantic.types import conlist
 
 from .base_model import BaseModel
+from .utils import HashableMapping, HashableSequence
 from .shared import BiolinkEntity, BiolinkPredicate, CURIE
 
 
@@ -74,7 +76,7 @@ class QNode(BaseModel):
         nullable=True,
     )
     is_set: bool = False
-    constraints: Optional[List[QueryConstraint]] = Field(
+    constraints: Optional[HashableSequence[QueryConstraint]] = Field(
         [],
         title='constraints',
     )
@@ -101,7 +103,7 @@ class QEdge(BaseModel):
         title='predicates',
         nullable=True,
     )
-    constraints: Optional[List[QueryConstraint]] = Field(
+    constraints: Optional[HashableSequence[QueryConstraint]] = Field(
         [],
         title='constraints',
     )
@@ -115,11 +117,11 @@ class QEdge(BaseModel):
 class QueryGraph(BaseModel):
     """Query graph."""
 
-    nodes: Dict[str, QNode] = Field(
+    nodes: HashableMapping[str, QNode] = Field(
         ...,
         title='dict of nodes',
     )
-    edges: Dict[str, QEdge] = Field(
+    edges: HashableMapping[str, QEdge] = Field(
         ...,
         title='dict of edges',
     )

--- a/reasoner_pydantic/results.py
+++ b/reasoner_pydantic/results.py
@@ -1,8 +1,9 @@
 """Results models."""
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
+from .base_model import BaseModel
 from .shared import Attribute, CURIE
 
 

--- a/reasoner_pydantic/results.py
+++ b/reasoner_pydantic/results.py
@@ -1,9 +1,10 @@
 """Results models."""
-from typing import Dict, List, Optional
+from typing import Optional
 
 from pydantic import Field
 
 from .base_model import BaseModel
+from .utils import HashableMapping, HashableSequence
 from .shared import Attribute, CURIE
 
 
@@ -15,7 +16,7 @@ class EdgeBinding(BaseModel):
         title='knowledge graph id',
     )
 
-    attributes: Optional[List[Attribute]] = Field(None, nullable=True)
+    attributes: Optional[HashableSequence[Attribute]] = Field(None, nullable=True)
 
     class Config:
         title = 'edge binding'
@@ -48,11 +49,11 @@ class NodeBinding(BaseModel):
 class Result(BaseModel):
     """Result."""
 
-    node_bindings: Dict[str, List[NodeBinding]] = Field(
+    node_bindings: HashableMapping[str, HashableSequence[NodeBinding]] = Field(
         ...,
         title='list of node bindings',
     )
-    edge_bindings: Dict[str, List[EdgeBinding]] = Field(
+    edge_bindings: HashableMapping[str, HashableSequence[EdgeBinding]] = Field(
         ...,
         title='list of edge bindings',
     )

--- a/reasoner_pydantic/shared.py
+++ b/reasoner_pydantic/shared.py
@@ -3,7 +3,9 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, constr, Field
+from pydantic import constr, Field
+
+from .base_model import BaseModel
 
 
 class CURIE(BaseModel):

--- a/reasoner_pydantic/shared.py
+++ b/reasoner_pydantic/shared.py
@@ -4,9 +4,10 @@ from enum import Enum
 from typing import Any, Optional
 
 from pydantic import constr, Field
+from pydantic.class_validators import validator
 
 from .base_model import BaseModel
-from .utils import HashableSequence
+from .utils import HashableSequence, make_hashable
 
 
 class CURIE(BaseModel):
@@ -20,6 +21,8 @@ class SubAttribute(BaseModel):
 
     attribute_type_id: CURIE = Field(..., title="type")
     value: Any = Field(..., title="value")
+    _make_value_hashable = \
+        validator("value", allow_reuse=True)(make_hashable)
     value_type_id: Optional[CURIE] = Field(
         None,
         title="value_type_id",
@@ -39,6 +42,8 @@ class Attribute(BaseModel):
 
     attribute_type_id: CURIE = Field(..., title="type")
     value: Any = Field(..., title="value")
+    _make_value_hashable = \
+        validator("value", allow_reuse=True)(make_hashable)
     value_type_id: Optional[CURIE] = Field(
         None,
         title="value_type_id",

--- a/reasoner_pydantic/shared.py
+++ b/reasoner_pydantic/shared.py
@@ -1,11 +1,12 @@
 """Shared models."""
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from pydantic import constr, Field
 
 from .base_model import BaseModel
+from .utils import HashableSequence
 
 
 class CURIE(BaseModel):
@@ -47,7 +48,7 @@ class Attribute(BaseModel):
     value_url: Optional[str] = Field(None, nullable=True)
     attribute_source: Optional[str] = Field(None, nullable=True)
     description: Optional[str] = Field(None, nullable=True)
-    attributes: Optional[List[SubAttribute]] = Field(None, nullable=True)
+    attributes: Optional[HashableSequence[SubAttribute]] = Field(None, nullable=True)
 
     class Config:
         extra = "forbid"

--- a/reasoner_pydantic/utils.py
+++ b/reasoner_pydantic/utils.py
@@ -125,12 +125,12 @@ def make_hashable(o):
     o_type = str(type(o))
 
     if "dict" in o_type:
-        return HashableMapping((
+        return HashableMapping.parse_obj((
             (k, make_hashable(v))
             for k,v in o.items()
         ))
     if "list" in o_type:
-        return HashableSequence(
+        return HashableSequence.parse_obj(
             make_hashable(v)
             for v in o
         )

--- a/reasoner_pydantic/utils.py
+++ b/reasoner_pydantic/utils.py
@@ -1,0 +1,111 @@
+import collections
+from typing import Dict, List, Generic, TypeVar
+
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic.fields import ModelField
+
+KeyType = TypeVar('KeyType')
+ValueType = TypeVar('ValueType')
+
+class HashableMapping(PydanticBaseModel, Generic[KeyType, ValueType]):
+    """
+    Custom class that implements MutableMapping and is hashable
+
+    Hash will be recomputed if items are updated or deleted. The
+    hash can be considered valid if the values are immutable.
+    """
+    __root__: Dict[KeyType, ValueType]
+
+    _hash = None
+
+    def __getitem__(self, k):
+        return self.__root__[k]
+    def __iter__(self):
+        return iter(self.__root__)
+    def __len__(self):
+        return len(self.__root__)
+
+    def __setitem__(self, k, v):
+        # Invalidate hash
+        self._hash = None
+        self.__root__[k] = v
+    def __delitem__(self, k):
+        # Invalidate hash
+        self._hash = None
+        del self.__root__[k]
+
+    def __hash__(self):
+        if self._hash is None:
+            h = 0
+            for key, value in self.__root__.items():
+                h ^= hash((key, value))
+            self._hash = h
+        return self._hash
+
+    def __repr__(self):
+        return repr(self.__root__)
+
+
+class HashableSequence(PydanticBaseModel, Generic[ValueType]):
+    """
+    Custom class that implements MutableSequence and is hashable
+
+    Hash will be recomputed if items are updated or deleted. The
+    hash can be considered valid if the values are immutable.
+    """
+    __root__: List[ValueType]
+
+    _hash = None
+
+    def __getitem__(self, i):
+        return self.__root__[i]
+    def __iter__(self):
+        return iter(self.__root__)
+    def __len__(self):
+        return len(self.__root__)
+
+    def __setitem__(self, i, v):
+        # Invalidate hash
+        self._hash = None
+        self.__root__[i] = v
+    def __delitem__(self, i):
+        # Invalidate hash
+        self._hash = None
+        del self.__root__[i]
+    def insert(self, i, v):
+        # Invalidate hash
+        self._hash = None
+        self.__root__.insert(i, v)
+
+    def __hash__(self):
+        if self._hash is None:
+            h = 0
+            for value in self.__root__:
+                h ^= hash(value)
+            self._hash = h
+        return self._hash
+
+def make_hashable(o):
+    """
+    Convert a generic Python object to a hashable one recursively
+
+    This is an expensive operation, so it is best used sparingly
+    """
+
+    # type(o) is faster than isinstance(o) because it doesn't
+    # traverse the inheritance hierarchy
+    o_type = str(type(o))
+
+    if "dict" in o_type:
+        return HashableMapping((
+            (k, make_hashable(v))
+            for k,v in o.items()
+        ))
+    if "list" in o_type:
+        return HashableSequence(
+            make_hashable(v)
+            for v in o
+        )
+
+    return o
+

--- a/reasoner_pydantic/utils.py
+++ b/reasoner_pydantic/utils.py
@@ -47,10 +47,7 @@ class HashableMapping(
 
     def __hash__(self):
         if self._hash is None:
-            h = 0
-            for key, value in self.__root__.items():
-                h ^= hash((key, value))
-            self._hash = h
+            self._hash = hash(tuple((k,v) for k,v in self.__root__.items()))
         return self._hash
 
     def invalidate_hash(self):
@@ -103,10 +100,7 @@ class HashableSequence(
 
     def __hash__(self):
         if self._hash is None:
-            h = 0
-            for value in self.__root__:
-                h ^= hash(value)
-            self._hash = h
+            self._hash = hash(tuple(self.__root__))
         return self._hash
 
     def invalidate_hash(self):

--- a/reasoner_pydantic/utils.py
+++ b/reasoner_pydantic/utils.py
@@ -1,13 +1,12 @@
 import collections
 from typing import Dict, List, Generic, TypeVar
 
-from pydantic import BaseModel as PydanticBaseModel
-from pydantic.fields import ModelField
+from pydantic.generics import GenericModel
 
 KeyType = TypeVar('KeyType')
 ValueType = TypeVar('ValueType')
 
-class HashableMapping(PydanticBaseModel, Generic[KeyType, ValueType]):
+class HashableMapping(GenericModel, Generic[KeyType, ValueType]):
     """
     Custom class that implements MutableMapping and is hashable
 
@@ -17,6 +16,7 @@ class HashableMapping(PydanticBaseModel, Generic[KeyType, ValueType]):
     __root__: Dict[KeyType, ValueType]
 
     _hash = None
+
 
     def __getitem__(self, k):
         return self.__root__[k]
@@ -46,7 +46,7 @@ class HashableMapping(PydanticBaseModel, Generic[KeyType, ValueType]):
         return repr(self.__root__)
 
 
-class HashableSequence(PydanticBaseModel, Generic[ValueType]):
+class HashableSequence(GenericModel, Generic[ValueType]):
     """
     Custom class that implements MutableSequence and is hashable
 

--- a/reasoner_pydantic/utils.py
+++ b/reasoner_pydantic/utils.py
@@ -7,7 +7,11 @@ from pydantic.generics import GenericModel
 KeyType = TypeVar('KeyType')
 ValueType = TypeVar('ValueType')
 
-class HashableMapping(GenericModel, Generic[KeyType, ValueType]):
+class HashableMapping(
+        GenericModel,
+        Generic[KeyType, ValueType],
+        collections.abc.MutableMapping,
+):
     """
     Custom class that implements MutableMapping and is hashable
 
@@ -57,7 +61,11 @@ class HashableMapping(GenericModel, Generic[KeyType, ValueType]):
             self._invalidate_hook()
 
 
-class HashableSequence(GenericModel, Generic[ValueType]):
+class HashableSequence(
+        GenericModel,
+        Generic[ValueType],
+        collections.abc.MutableSequence,
+):
     """
     Custom class that implements MutableSequence and is hashable
 

--- a/reasoner_pydantic/workflow.py
+++ b/reasoner_pydantic/workflow.py
@@ -2,9 +2,9 @@
 from enum import Enum
 from typing import Any, List, Optional, Union
 
-from pydantic import BaseModel
 from pydantic.types import confloat, conint, conlist
 
+from .base_model import BaseModel
 
 def constant(s: str):
     """Generate a static enum."""

--- a/reasoner_pydantic/workflow.py
+++ b/reasoner_pydantic/workflow.py
@@ -1,10 +1,11 @@
 """Operations models."""
 from enum import Enum
-from typing import Any, List, Optional, Union
+from typing import Any,  Optional, Union
 
 from pydantic.types import confloat, conint, conlist
 
 from .base_model import BaseModel
+from .utils import HashableMapping, HashableSequence
 
 def constant(s: str):
     """Generate a static enum."""
@@ -20,7 +21,7 @@ class OperationAnnotate(BaseModel):
 
 
 class AnnotateEdgesParameters(BaseModel):
-    attributes: Optional[List[str]]
+    attributes: Optional[HashableSequence[str]]
 
 
 class OperationAnnotateEdges(BaseModel):
@@ -32,7 +33,7 @@ class OperationAnnotateEdges(BaseModel):
 
 
 class AnnotateNodesParameters(BaseModel):
-    attributes: Optional[List[str]]
+    attributes: Optional[HashableSequence[str]]
 
 
 class OperationAnnotateNodes(BaseModel):
@@ -61,7 +62,7 @@ class OperationCompleteResults(BaseModel):
 
 class EnrichResultsParameters(BaseModel):
     pvalue_threshold: confloat(ge=0.0, le=1.0) = 1e-6
-    qnode_keys: Optional[List[str]]
+    qnode_keys: Optional[HashableSequence[str]]
 
 
 class OperationEnrichResults(BaseModel):
@@ -139,8 +140,8 @@ class FilterKgraphContinuousKedgeAttributeParameters(BaseModel):
     edge_attribute: str
     threshold: float
     remove_above_or_below: AboveOrBelowEnum
-    qedge_keys: Optional[List[str]]
-    qnode_keys: List[str] = []
+    qedge_keys: Optional[HashableSequence[str]]
+    qnode_keys: HashableSequence[str] = []
 
 
 class OperationFilterKgraphContinuousKedgeAttribute(BaseModel):
@@ -154,8 +155,8 @@ class OperationFilterKgraphContinuousKedgeAttribute(BaseModel):
 class FilterKgraphDiscreteKedgeAttributeParameters(BaseModel):
     edge_attribute: str
     remove_value: Any
-    qedge_keys: Optional[List[str]]
-    qnode_keys: List[str] = []
+    qedge_keys: Optional[HashableSequence[str]]
+    qnode_keys: HashableSequence[str] = []
 
 
 class OperationFilterKgraphDiscreteKedgeAttribute(BaseModel):
@@ -169,7 +170,7 @@ class OperationFilterKgraphDiscreteKedgeAttribute(BaseModel):
 class FilterKgraphDiscreteKnodeAttributeParameters(BaseModel):
     node_attribute: str
     remove_value: Any
-    qnode_keys: Optional[List[str]]
+    qnode_keys: Optional[HashableSequence[str]]
 
 
 class OperationFilterKgraphDiscreteKnodeAttribute(BaseModel):
@@ -198,16 +199,16 @@ class FilterKgraphTopNParameters(BaseModel):
     edge_attribute: str
     max_edges: conint(le=0) = 50
     remove_top_or_bottom: TopOrBottomEnum = TopOrBottomEnum.top
-    qedge_keys: Optional[List[str]]
-    qnode_keys: List[str] = []
+    qedge_keys: Optional[HashableSequence[str]]
+    qnode_keys: HashableSequence[str] = []
 
 
 class FilterKgraphPercentileParameters(BaseModel):
     edge_attribute: str
     threshold: confloat(ge=0, le=100) = 95
     remove_above_or_below: AboveOrBelowEnum = AboveOrBelowEnum.below
-    qedge_keys: Optional[List[str]]
-    qnode_keys: List[str] = []
+    qedge_keys: Optional[HashableSequence[str]]
+    qnode_keys: HashableSequence[str] = []
 
 
 class OperationFilterKgraphPercentile(BaseModel):
@@ -229,8 +230,8 @@ class FilterKgraphStdDevParameters(BaseModel):
     plus_or_minus_std_dev: PlusOrMinusEnum = PlusOrMinusEnum.plus
     num_sigma: confloat(ge=0) = 1
     remove_above_or_below: AboveOrBelowEnum = AboveOrBelowEnum.below
-    qedge_keys: Optional[List[str]]
-    qnode_keys: List[str] = []
+    qedge_keys: Optional[HashableSequence[str]]
+    qnode_keys: HashableSequence[str] = []
 
 
 class OperationFilterKgraphStdDev(BaseModel):
@@ -267,7 +268,7 @@ class OperationOverlay(BaseModel):
 
 class OverlayComputeJaccardParameters(BaseModel):
     intermediate_node_key: str
-    end_node_keys: List[str]
+    end_node_keys: HashableSequence[str]
     virtual_relation_label: str
 
 
@@ -280,7 +281,7 @@ class OperationOverlayComputeJaccard(BaseModel):
 
 
 class OverlayComputeNgdParameters(BaseModel):
-    qnode_keys: List[str]
+    qnode_keys: HashableSequence[str]
     virtual_relation_label: str
 
 
@@ -348,7 +349,7 @@ class AscOrDescEnum(str, Enum):
 class SortResultsEdgeAttributeParameters(BaseModel):
     edge_attribute: str
     ascending_or_descending: AscOrDescEnum
-    qedge_keys: Optional[List[str]]
+    qedge_keys: Optional[HashableSequence[str]]
 
 
 class OperationSortResultsEdgeAttribute(BaseModel):
@@ -362,7 +363,7 @@ class OperationSortResultsEdgeAttribute(BaseModel):
 class SortResultsNodeAttributeParameters(BaseModel):
     node_attribute: str
     ascending_or_descending: AscOrDescEnum
-    qnode_keys: Optional[List[str]]
+    qnode_keys: Optional[HashableSequence[str]]
 
 
 class OperationSortResultsNodeAttribute(BaseModel):
@@ -453,4 +454,4 @@ class Operation(BaseModel):
 
 
 class Workflow(BaseModel):
-    __root__: List[Operation]
+    __root__: HashableSequence[Operation]

--- a/reasoner_pydantic/workflow.py
+++ b/reasoner_pydantic/workflow.py
@@ -1,11 +1,12 @@
 """Operations models."""
 from enum import Enum
 from typing import Any,  Optional, Union
+from pydantic.class_validators import validator
 
-from pydantic.types import confloat, conint, conlist
+from pydantic.types import confloat, conint
 
 from .base_model import BaseModel
-from .utils import HashableMapping, HashableSequence
+from .utils import HashableMapping, HashableSequence, nonzero_validator
 
 def constant(s: str):
     """Generate a static enum."""
@@ -74,14 +75,18 @@ class OperationEnrichResults(BaseModel):
 
 
 class FillAllowParameters(BaseModel):
-    allowlist: conlist(str, min_items=1)
+    allowlist: HashableSequence[str]
+    _nonzero_allowlist = \
+        validator('allowlist', allow_reuse=True)(nonzero_validator)
 
     class Config:
         extra = "forbid"
 
 
 class FillDenyParameters(BaseModel):
-    denylist: conlist(str, min_items=1)
+    denylist: HashableSequence[str]
+    _nonzero_denylist = \
+        validator('denylist', allow_reuse=True)(nonzero_validator)
 
     class Config:
         extra = "forbid"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,5 @@
 from reasoner_pydantic.shared import Attribute, BiolinkEntity
-from reasoner_pydantic.message import Message
-from reasoner_pydantic import Query, QNode, QEdge
+from reasoner_pydantic import Message, QNode, QEdge, QueryGraph
 
 def test_qnode_null_properties():
     """ Check that we can parse a QNode with None property values """
@@ -68,6 +67,17 @@ def test_hash_list_update():
 
     qnode.categories.append("biolink:Disease")
     assert hash(qnode) != h
+
+def test_hash_dict_update():
+    """ Check that we can update a dict property on an object and the hash changes """
+
+    # Test on a QueryGraph
+    kg = QueryGraph.parse_obj(EXAMPLE_MESSAGE["query_graph"])
+    h = hash(kg)
+
+    kg.nodes["n0"] = kg.nodes["n1"]
+
+    assert hash(kg) != h
 
 
 def test_hash_deeply_nested_update():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,4 @@
-from reasoner_pydantic.shared import BiolinkEntity
+from reasoner_pydantic.shared import Attribute, BiolinkEntity
 from reasoner_pydantic.message import Message
 from reasoner_pydantic import Query, QNode, QEdge
 
@@ -84,3 +84,14 @@ def test_hash_deeply_nested_update():
 
     assert hash(m) != h
 
+
+def test_hash_attribute_values():
+    """
+    Check that we can hash a dictionary valued attribute
+    """
+
+    a = Attribute.parse_obj({
+        "attribute_type_id": "biolink:knowledge_source",
+        "value": {"sources" : ["a", "b", "c"]},
+    })
+    assert hash(a)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
-from reasoner_pydantic import QNode, QEdge
+from reasoner_pydantic import Message, QNode, QEdge
+from reasoner_pydantic.utils import HashableMapping
 
 def test_qnode_null_properties():
     """ Check that we can parse a QNode with None property values """
@@ -14,3 +15,22 @@ def test_qedge_null_properties():
         "object" : "n1",
         "predicates": None,
     })
+
+def test_hashable_message():
+    """ Check that we can hash and update a message correctly """
+    m = Message.parse_obj({
+        "query_graph": {
+            "nodes" : {
+                "n1" : {"categories" : ["biolink:ChemicalSubstance"]}
+            },
+            "edges" : {}
+        },
+        "knowledge_graph": {
+            "nodes" : {},
+            "edges" : {}
+        },
+        "results": [],
+    })
+
+    assert isinstance(m.query_graph.nodes, HashableMapping) # HashableMapping
+    assert isinstance(m.query_graph.nodes["n1"], HashableMapping) # dict??

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -66,7 +66,7 @@ def test_hash_list_update():
     qnode = QNode.parse_obj({"categories" : ["biolink:ChemicalSubstance"]})
     h = hash(qnode)
 
-    qnode.categories.insert(0, "biolink:Disease")
+    qnode.categories.append("biolink:Disease")
     assert hash(qnode) != h
 
 
@@ -78,8 +78,8 @@ def test_hash_deeply_nested_update():
     m = Message.parse_obj(EXAMPLE_MESSAGE)
     h = hash(m)
 
-    m.query_graph.nodes['n1'].categories.insert(
-        0, BiolinkEntity.parse_obj("biolink:Gene")
+    m.query_graph.nodes['n1'].categories.append(
+        BiolinkEntity.parse_obj("biolink:Gene")
     )
 
     assert hash(m) != h


### PR DESCRIPTION
Added a __hash__ method to all models. This should allow for much more efficient merging in Strider. After this is done, I can go through and add `.update(o)` methods to each Pydantic object. This encapsulates the code required for merging. 

The hashing is achieved by using a custom model for Lists and Dicts (HashableSequence and HashableMapping) as well as a custom BaseModel for all other objects. To facilitate efficient repeated hash() calls the method is memoized and invalidated on changes to attributes. If a nested object is modified, the invalidation propagates upwards to all parent objects.