### PR TITLE
Remove hash caching

### DIFF
--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -20,48 +20,4 @@ def test_hash_property_update():
     assert hash(qnode) != h
 ```
 
-There are two ways to achieve this result. One is to define a hash function which recomputes the hash every time it is called. Another is to save the computed hash to the object and then remove the saved hash if there is a change. Currently, reasoner-pydantic uses the second method. To implement this, it is important to invalidate the hash if the object, or any children of the object, change. Here is another example:
-
-```python
-def test_hash_deeply_nested_update():
-    """
-    Check that we can update a deeply nested object and the hash change is propogated
-    """
-
-    m = Message.parse_obj(EXAMPLE_MESSAGE)
-    h = hash(m)
-
-    m.query_graph.nodes["n1"].categories.append(BiolinkEntity.parse_obj("biolink:Gene"))
-
-    assert hash(m) != h
-```
-
-We have to ensure that a deeply nested change is propogated upwards to invalidate the hash of all parent objects. To achieve this, we have a [custom base model](reasoner_pydantic/base_model.py) for all objects that looks something like this:
-
-```python
-class BaseModel(PydanticBaseModel):
-    _hash: int
-    _invalidate_hook: Callable
-    
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Give nested objects a hook that they
-        # can use to invalidate hash on this object
-        for value in self.__dict__.values():
-            if hasattr(value, "_invalidate_hook"):
-                value._invalidate_hook = self.invalidate_hash
-
-    def invalidate_hash(self):
-        """Invalidate stored hash value"""
-        self._hash = None
-        # Propogate
-        if self._invalidate_hook:
-            self._invalidate_hook()
-
-    def __setattr__(self, name, value):
-        """Custom setattr that invalidates hash"""
-        self.invalidate_hash()
-        return super().__setattr__(name, value)
-```
-
-We have similar code in place for lists, dicts, and sets, which can be found in the [reasoner_pydantic/utils.py](reasoner_pydantic/utils.py) file. When implemented properly, these methods provide the basis for efficient in-place object merging.
+To achieve this, we have a [custom base model](reasoner_pydantic/base_model.py) for all objects that includes a hash function. This hash function recurses down through the object and computes the hash for the entire object when called. We have similar code in place for lists, dicts, and sets, which can be found in the [reasoner_pydantic/utils.py](reasoner_pydantic/utils.py) file. When implemented properly, this provide the basis for efficient in-place object merging.

--- a/reasoner_pydantic/base_model.py
+++ b/reasoner_pydantic/base_model.py
@@ -7,11 +7,7 @@ class BaseModel(PydanticBaseModel):
     """
     Custom base model for all classes
 
-    This provides a hash function that assumes all fields are either:
-
-    1. Immutable
-    2. Derived from BaseModel
-    3. Able to call a hash invalidation hook on their own
+    This provides hash and equality methods.
     """
 
     def __hash__(self) -> int:
@@ -21,13 +17,6 @@ class BaseModel(PydanticBaseModel):
     def __eq__(self, other) -> bool:
         """Equality function that calls hash function"""
         return self.__hash__() == other.__hash__()
-
-    def invalidate_hash(self):
-        """Invalidate stored hash value"""
-        self._hash = None
-        # Propogate
-        if self._invalidate_hook:
-            self._invalidate_hook()
 
     def update(self, other):
         """Update fields on this object with fields from other object"""

--- a/reasoner_pydantic/utils.py
+++ b/reasoner_pydantic/utils.py
@@ -15,21 +15,9 @@ class HashableMapping(
 ):
     """
     Custom class that implements MutableMapping and is hashable
-
-    Hash will be recomputed if items are updated or deleted. The
-    hash can be considered valid if the values are immutable.
     """
 
     __root__: Dict[KeyType, ValueType] = dict()
-
-    _hash: Optional[int] = PrivateAttr(default=None)
-    _invalidate_hook: Optional[Callable] = PrivateAttr(default=None)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        for value in self.__root__.values():
-            if hasattr(value, "_invalidate_hook"):
-                value._invalidate_hook = self.invalidate_hash  # type: ignore
 
     def __getitem__(self, k):
         return self.__root__[k]
@@ -41,29 +29,16 @@ class HashableMapping(
         return len(self.__root__)
 
     def __setitem__(self, k, v):
-        self.invalidate_hash()
-        if hasattr(v, "_invalidate_hook"):
-            v._invalidate_hook = self.invalidate_hash
         self.__root__[k] = v
 
     def __delitem__(self, k):
-        self.invalidate_hash()
         del self.__root__[k]
 
     def __hash__(self):
-        if self._hash is None:
-            self._hash = hash(tuple((k, v) for k, v in self.__root__.items()))
-        return self._hash
+        return hash(tuple((k, v) for k, v in self.__root__.items()))
 
     def __eq__(self, other) -> bool:
         return self.__hash__() == other.__hash__()
-
-    def invalidate_hash(self):
-        """Invalidate stored hash value"""
-        self._hash = None
-        # Propogate
-        if self._invalidate_hook:
-            self._invalidate_hook()
 
 
 class HashableSequence(
@@ -73,20 +48,9 @@ class HashableSequence(
 ):
     """
     Custom class that implements MutableSequence and is hashable
-
-    Hash will be recomputed if items are updated or deleted. The
-    hash can be considered valid if the values are immutable.
     """
 
     __root__: List[ValueType] = list()
-    _hash: Optional[int] = PrivateAttr(default=None)
-    _invalidate_hook: Optional[Callable] = PrivateAttr(default=None)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        for value in self.__root__:
-            if hasattr(value, "_invalidate_hook"):
-                value._invalidate_hook = self.invalidate_hash  # type: ignore
 
     def __getitem__(self, i):
         return self.__root__[i]
@@ -98,33 +62,19 @@ class HashableSequence(
         return len(self.__root__)
 
     def __setitem__(self, i, v):
-        self.invalidate_hash()
-        if hasattr(v, "_invalidate_hook"):
-            v._invalidate_hook = self.invalidate_hash
         self.__root__[i] = v
 
     def __delitem__(self, i):
-        self.invalidate_hash()
         del self.__root__[i]
 
     def insert(self, i, v):
-        self.invalidate_hash()
         self.__root__.insert(i, v)
 
     def __hash__(self):
-        if self._hash is None:
-            self._hash = hash(tuple(self.__root__))
-        return self._hash
+        return hash(tuple(self.__root__))
 
     def __eq__(self, other) -> bool:
         return self.__hash__() == other.__hash__()
-
-    def invalidate_hash(self):
-        """Invalidate stored hash value"""
-        self._hash = None
-        # Propogate
-        if self._invalidate_hook:
-            self._invalidate_hook()
 
 
 class HashableSet(
@@ -134,20 +84,9 @@ class HashableSet(
 ):
     """
     Custom class that implements MutableSet and is hashable
-
-    Hash will be recomputed if items are updated or deleted. The
-    hash can be considered valid if the values are immutable.
     """
 
     __root__: Set[ValueType] = set()
-    _hash: Optional[int] = PrivateAttr(default=None)
-    _invalidate_hook: Optional[Callable] = PrivateAttr(default=None)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        for value in self.__root__:
-            if hasattr(value, "_invalidate_hook"):
-                value._invalidate_hook = self.invalidate_hash  # type: ignore
 
     def __contains__(self, v):
         return v in self.__root__
@@ -159,32 +98,18 @@ class HashableSet(
         return len(self.__root__)
 
     def add(self, v):
-        self.invalidate_hash()
-        if hasattr(v, "_invalidate_hook"):
-            v._invalidate_hook = self.invalidate_hash
         self.__root__.add(v)
 
     def update(self, other):
-        self.invalidate_hash()
         self.__root__.update(other)
 
     def discard(self, v):
-        self.invalidate_hash()
         self.__root__.discard(v)
 
     def __hash__(self):
-        if self._hash is None:
-            # Use frozenset instead of tuple to ensure
-            # hash is computed without ordering of elements
-            self._hash = hash(frozenset(self.__root__))
-        return self._hash
-
-    def invalidate_hash(self):
-        """Invalidate stored hash value"""
-        self._hash = None
-        # Propogate
-        if self._invalidate_hook:
-            self._invalidate_hook()
+        # Use frozenset instead of tuple to ensure
+        # hash is computed without ordering of elements
+        return hash(frozenset(self.__root__))
 
     def dict(self, *args, **kwargs):
         """Custom serialization method to convert to list"""

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="reasoner-pydantic",
-    version="2.1.0",
+    version="2.1.1",
     author="Kenneth Morton",
     author_email="kenny@covar.com",
     url="https://github.com/TranslatorSRI/reasoner-pydantic",


### PR DESCRIPTION
Hash caching is cool, but it has a couple of disadvantages:

1. It is about 30% slower for Strider's use case, due to the high write/read ratio in merging.
2. It is currently causing a bug where [deep copies fail because cyclical references can't be pickled](https://stackoverflow.com/questions/46283738/attributeerror-when-using-python-deepcopy).

Based on these, I think it makes sense to remove. This could be re-added later if the performance could be improved.