### PR TITLE
Fix flaky test part 2

### DIFF
--- a/reasoner_pydantic/utils.py
+++ b/reasoner_pydantic/utils.py
@@ -109,7 +109,7 @@ class HashableSet(
     def __hash__(self):
         # Use frozenset instead of tuple to ensure
         # hash is computed without ordering of elements
-        return hash(frozenset(self.__root__))
+        return hash(frozenset(self))
 
     def dict(self, *args, **kwargs):
         """Custom serialization method to convert to list"""

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="reasoner-pydantic",
-    version="2.1.1",
+    version="2.1.2",
     author="Kenneth Morton",
     author_email="kenny@covar.com",
     url="https://github.com/TranslatorSRI/reasoner-pydantic",


### PR DESCRIPTION
Turns out the `frozenset` constructor will just use the hash of the `set` object if you give it a set. Instead, we need to compute the hash by constructing a new frozenset from an iterator. This fixes that issue.