### PR TITLE
Fix result validation

### DIFF
--- a/reasoner_pydantic/base_model.py
+++ b/reasoner_pydantic/base_model.py
@@ -1,7 +1,8 @@
 from pydantic import BaseModel as PydanticBaseModel
 
 from pydantic.class_validators import root_validator
-from .utils import HashableMapping, HashableSequence, make_hashable
+from .utils import make_hashable
+
 
 class BaseModel(PydanticBaseModel):
     """
@@ -24,27 +25,8 @@ class BaseModel(PydanticBaseModel):
             f"Model {self.__class__.__name__} has no update method"
         )
 
-    def make_hashable(cls, values):
-        """
-        Convert a generic Python object to a hashable one recursively
-
-        This is an expensive operation, so it is best used sparingly
-        """
-
-        # type(o) is faster than isinstance(o) because it doesn't
-        # traverse the inheritance hierarchy
-        o_type = str(type(values))
-        
-        new_value = values
-        if "dict" in o_type:
-            new_value = HashableMapping.parse_obj(((k, cls.make_hashable(v)) for k, v in values.items()))
-        if "list" in o_type:
-            new_value = HashableSequence.parse_obj(cls.make_hashable(v) for v in values)
-
-        return new_value
-
+    # After running validation on all known properties, make sure everything else is hashable
     @root_validator(allow_reuse=True, pre=False)
     def make_hashable_root(cls, values):
         # The root validator must take and return a dict
-        return {k: make_hashable(k) for k, v in values.items()}
-
+        return {k: make_hashable(v) for k, v in values.items()}

--- a/reasoner_pydantic/base_model.py
+++ b/reasoner_pydantic/base_model.py
@@ -1,7 +1,7 @@
-from typing import Callable, Optional
-import weakref
-from pydantic import BaseModel as PydanticBaseModel, PrivateAttr
+from pydantic import BaseModel as PydanticBaseModel
 
+from pydantic.class_validators import root_validator
+from .utils import HashableMapping, HashableSequence, make_hashable
 
 class BaseModel(PydanticBaseModel):
     """
@@ -23,3 +23,28 @@ class BaseModel(PydanticBaseModel):
         raise NotImplementedError(
             f"Model {self.__class__.__name__} has no update method"
         )
+
+    def make_hashable(cls, values):
+        """
+        Convert a generic Python object to a hashable one recursively
+
+        This is an expensive operation, so it is best used sparingly
+        """
+
+        # type(o) is faster than isinstance(o) because it doesn't
+        # traverse the inheritance hierarchy
+        o_type = str(type(values))
+        
+        new_value = values
+        if "dict" in o_type:
+            new_value = HashableMapping.parse_obj(((k, cls.make_hashable(v)) for k, v in values.items()))
+        if "list" in o_type:
+            new_value = HashableSequence.parse_obj(cls.make_hashable(v) for v in values)
+
+        return new_value
+
+    @root_validator(allow_reuse=True, pre=False)
+    def make_hashable_root(cls, values):
+        # The root validator must take and return a dict
+        return {k: make_hashable(k) for k, v in values.items()}
+

--- a/reasoner_pydantic/kgraph.py
+++ b/reasoner_pydantic/kgraph.py
@@ -1,11 +1,11 @@
 """Knowledge graph models."""
-from typing import Optional, Union
+from typing import Optional
 
 from pydantic import Field
 
 from .shared import Attribute, BiolinkEntity, BiolinkPredicate, CURIE, EdgeIdentifier
 from .base_model import BaseModel
-from .utils import HashableMapping, HashableSequence, HashableSet
+from .utils import HashableMapping, HashableSet
 
 
 class Node(BaseModel):

--- a/reasoner_pydantic/message.py
+++ b/reasoner_pydantic/message.py
@@ -1,7 +1,7 @@
 """Reasoner API models."""
 import hashlib
 
-from typing import Optional, Set, Callable
+from typing import Optional, Callable
 
 from pydantic import constr, Field
 

--- a/reasoner_pydantic/qgraph.py
+++ b/reasoner_pydantic/qgraph.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 from pydantic.class_validators import validator
 from reasoner_pydantic.utils import HashableMapping
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from pydantic import Field
 

--- a/reasoner_pydantic/results.py
+++ b/reasoner_pydantic/results.py
@@ -7,6 +7,7 @@ from .base_model import BaseModel
 from .utils import HashableMapping, HashableSet
 from .shared import Attribute, CURIE
 
+
 class EdgeBinding(BaseModel):
     """Edge binding."""
 
@@ -60,11 +61,6 @@ class Result(BaseModel):
         None,
         format="float",
     )
-    # these lines work
-    # raw_data: Optional[Any] = Field(
-    #     None
-    # )
-    # _make_fields_hashable = validator("*", allow_reuse=True, check_fields=False)(make_hashable)
 
     class Config:
         title = "result"

--- a/reasoner_pydantic/results.py
+++ b/reasoner_pydantic/results.py
@@ -1,5 +1,5 @@
 """Results models."""
-from typing import Optional, Any
+from typing import Optional
 
 from pydantic import Field
 

--- a/reasoner_pydantic/results.py
+++ b/reasoner_pydantic/results.py
@@ -69,7 +69,7 @@ class Result(BaseModel):
     # _make_fields_hashable = validator("*", allow_reuse=True, check_fields=False)(make_hashable)
 
     # this isn't working
-    @root_validator(pre=True, allow_reuse=True)
+    @root_validator(allow_reuse=True)
     def make_hashable(cls, values):
         """
         Convert a generic Python object to a hashable one recursively
@@ -85,10 +85,12 @@ class Result(BaseModel):
 
         if "dict" in o_type:
             print('got a dict')
-            return HashableMapping.parse_obj(((k, cls.make_hashable(cls, v)) for k, v in values.items()))
+            return HashableMapping.parse_obj(((k, cls.make_hashable(v)) for k, v in values.items()))
         if "list" in o_type:
             print('got a list')
-            return HashableSequence.parse_obj(cls.make_hashable(cls, v) for v in values)
+            return HashableSequence.parse_obj(cls.make_hashable(v) for v in values)
+
+        print(f"values: {values}")
 
         return values
 

--- a/reasoner_pydantic/results.py
+++ b/reasoner_pydantic/results.py
@@ -5,7 +5,7 @@ from pydantic import Field
 from pydantic.class_validators import validator, root_validator
 
 from .base_model import BaseModel
-from .utils import HashableMapping, HashableSequence, HashableSet, make_hashable
+from .utils import HashableMapping, HashableSequence, HashableSet
 from .shared import Attribute, CURIE
 
 
@@ -85,10 +85,10 @@ class Result(BaseModel):
 
         if "dict" in o_type:
             print('got a dict')
-            return HashableMapping.parse_obj(((k, make_hashable(cls, v)) for k, v in values.items()))
+            return HashableMapping.parse_obj(((k, cls.make_hashable(cls, v)) for k, v in values.items()))
         if "list" in o_type:
             print('got a list')
-            return HashableSequence.parse_obj(make_hashable(cls, v) for v in values)
+            return HashableSequence.parse_obj(cls.make_hashable(cls, v) for v in values)
 
         return values
 

--- a/reasoner_pydantic/results.py
+++ b/reasoner_pydantic/results.py
@@ -2,12 +2,10 @@
 from typing import Optional, Any
 
 from pydantic import Field
-from pydantic.class_validators import validator, root_validator
 
 from .base_model import BaseModel
-from .utils import HashableMapping, HashableSequence, HashableSet
+from .utils import HashableMapping, HashableSet
 from .shared import Attribute, CURIE
-
 
 class EdgeBinding(BaseModel):
     """Edge binding."""
@@ -67,32 +65,6 @@ class Result(BaseModel):
     #     None
     # )
     # _make_fields_hashable = validator("*", allow_reuse=True, check_fields=False)(make_hashable)
-
-    # this isn't working
-    @root_validator(allow_reuse=True)
-    def make_hashable(cls, values):
-        """
-        Convert a generic Python object to a hashable one recursively
-
-        This is an expensive operation, so it is best used sparingly
-        """
-
-        # type(o) is faster than isinstance(o) because it doesn't
-        # traverse the inheritance hierarchy
-        o_type = str(type(values))
-        print(o_type)
-        print(values)
-
-        if "dict" in o_type:
-            print('got a dict')
-            return HashableMapping.parse_obj(((k, cls.make_hashable(v)) for k, v in values.items()))
-        if "list" in o_type:
-            print('got a list')
-            return HashableSequence.parse_obj(cls.make_hashable(v) for v in values)
-
-        print(f"values: {values}")
-
-        return values
 
     class Config:
         title = "result"

--- a/reasoner_pydantic/shared.py
+++ b/reasoner_pydantic/shared.py
@@ -4,12 +4,11 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Optional
 
-from pydantic import constr, Field
-from pydantic.class_validators import validator
+from pydantic import Field
 from pydantic.types import ConstrainedStr
 
 from .base_model import BaseModel
-from .utils import HashableSequence, make_hashable
+from .utils import HashableSequence
 
 
 class CURIE(str):
@@ -25,7 +24,6 @@ class SubAttribute(BaseModel):
 
     attribute_type_id: CURIE = Field(..., title="type")
     value: Any = Field(..., title="value")
-    _make_value_hashable = validator("value", allow_reuse=True)(make_hashable)
     value_type_id: Optional[CURIE] = Field(
         None,
         title="value_type_id",
@@ -45,7 +43,6 @@ class Attribute(BaseModel):
 
     attribute_type_id: CURIE = Field(..., title="type")
     value: Any = Field(..., title="value")
-    _make_value_hashable = validator("value", allow_reuse=True)(make_hashable)
     value_type_id: Optional[CURIE] = Field(
         None,
         title="value_type_id",

--- a/reasoner_pydantic/utils.py
+++ b/reasoner_pydantic/utils.py
@@ -1,7 +1,6 @@
 import collections.abc
-from typing import Callable, Dict, List, Generic, Set, TypeVar, Optional
+from typing import Dict, List, Generic, Set, TypeVar
 
-from pydantic import PrivateAttr
 from pydantic.generics import GenericModel
 
 KeyType = TypeVar("KeyType")

--- a/reasoner_pydantic/workflow.py
+++ b/reasoner_pydantic/workflow.py
@@ -6,7 +6,7 @@ from pydantic.class_validators import validator
 from pydantic.types import confloat, conint
 
 from .base_model import BaseModel
-from .utils import HashableMapping, HashableSequence, nonzero_validator
+from .utils import HashableSequence, nonzero_validator
 
 
 def constant(s: str):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="reasoner-pydantic",
-    version="2.2.1",
+    version="2.2.2",
     author="Kenneth Morton",
     author_email="kenny@covar.com",
     url="https://github.com/TranslatorSRI/reasoner-pydantic",

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,4 +1,5 @@
 from reasoner_pydantic import Result
+from reasoner_pydantic.utils import HashableSequence
 
 EXAMPLE_RESULT = {
     "node_bindings": {
@@ -18,19 +19,16 @@ EXAMPLE_RESULT = {
             },
         ],
     },
-    "raw_data": ["test"]
+    "raw_data": ["test"],
 }
 
 
 def test_result_hashable():
-    """Check that we can hash a result"""
+    """Check that we can hash a result with extra properties"""
 
-    m = Result.parse_obj(EXAMPLE_RESULT)
-    print(m)
-    h = hash(m)
-    assert h
+    result_obj = Result.parse_obj(EXAMPLE_RESULT)
+    result_dict = result_obj.dict()
 
-    m2 = Result.parse_obj(EXAMPLE_RESULT)
-    h2 = hash(m2)
-
-    assert h == h2
+    assert len(result_dict["raw_data"]) == 1
+    assert type(result_obj.raw_data) == HashableSequence
+    assert result_obj.raw_data[0] == "test"

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,0 +1,36 @@
+from reasoner_pydantic import Result
+
+EXAMPLE_RESULT = {
+    "node_bindings": {
+        "n1": [{"id": "CHEBI:6801"}],
+        "n2": [{"id": "MONDO:5148"}],
+    },
+    "edge_bindings": {
+        "n1n2": [
+            {
+                "id": "CHEBI:6801-biolink:treats-MONDO:5148",
+                "attributes": [
+                    {
+                        "attribute_type_id": "biolink:knowledge_source",
+                        "value": {"sources": ["a", "b", "c"]},
+                    }
+                ],
+            },
+        ],
+    },
+    "raw_data": ["test"]
+}
+
+
+def test_result_hashable():
+    """Check that we can hash a result"""
+
+    m = Result.parse_obj(EXAMPLE_RESULT)
+    print(m)
+    h = hash(m)
+    assert h
+
+    m2 = Result.parse_obj(EXAMPLE_RESULT)
+    h2 = hash(m2)
+
+    assert h == h2


### PR DESCRIPTION
Extra fields in results were failing pydantic validation. I've added a root validator decorator to the BaseModel so everything not already converted to a reasoner-pydantic type will be made hashable.