### PR TITLE
Updated ubuntu and python version in pypi action

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -10,13 +10,13 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish Python packages to PyPI and TestPyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.6
+    - name: Set up Python 3.11
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.11
     - name: Install setuptools and wheel
       run: >-
         python -m


### PR DESCRIPTION
Attempting to bump version and python requirements on GitHub action as runners with Ubuntu 18.04 have been deprecated.