### PR TITLE
Fix kl/at merging

### DIFF
--- a/reasoner_pydantic/base_model.py
+++ b/reasoner_pydantic/base_model.py
@@ -26,7 +26,7 @@ class BaseModel(PydanticBaseModel):
         raise NotImplementedError(
             f"Model {self.__class__.__name__} has no update method"
         )
-    
+
     def get_field(self, field):
         getattr(self, field, None)
 

--- a/reasoner_pydantic/base_model.py
+++ b/reasoner_pydantic/base_model.py
@@ -26,6 +26,9 @@ class BaseModel(PydanticBaseModel):
         raise NotImplementedError(
             f"Model {self.__class__.__name__} has no update method"
         )
+    
+    def get_field(self, field):
+        getattr(self, field, None)
 
     # After running validation on all known properties, make sure everything else is hashable
     @root_validator(allow_reuse=True, pre=False)

--- a/reasoner_pydantic/kgraph.py
+++ b/reasoner_pydantic/kgraph.py
@@ -103,7 +103,12 @@ class Edge(BaseModel):
     def update(self, other):
         if other.attributes:
             if self.attributes:
-                self.attributes.update(other.attributes)
+                # We need to make sure we don't add a second KL/AT
+                new_attributes = HashableSet[Attribute]
+                for attribute in other.attributes:
+                    if attribute.attribute_type_id not in ("biolink:knowledge_level", "biolink:agent_type"):
+                        new_attributes.add(attribute)
+                self.attributes.update(new_attributes)
             else:
                 self.attributes = other.attributes
         if other.sources:

--- a/reasoner_pydantic/kgraph.py
+++ b/reasoner_pydantic/kgraph.py
@@ -106,7 +106,10 @@ class Edge(BaseModel):
                 # We need to make sure we don't add a second KL/AT
                 new_attributes = HashableSet[Attribute]
                 for attribute in other.attributes:
-                    if attribute.attribute_type_id not in ("biolink:knowledge_level", "biolink:agent_type"):
+                    if attribute.attribute_type_id not in (
+                        "biolink:knowledge_level",
+                        "biolink:agent_type",
+                    ):
                         new_attributes.add(attribute)
                 self.attributes.update(new_attributes)
             else:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="reasoner-pydantic",
-    version="5.0.4",
+    version="5.0.5",
     author="Abrar Mesbah",
     author_email="amesbah@covar.com",
     url="https://github.com/TranslatorSRI/reasoner-pydantic",


### PR DESCRIPTION
Addresses both #81 and #80 

This update will remove extra KL/AT attributes when merging edges together. It doesn't use any creative logic here, and does not change the existing KL/AT attributes, even if the removed one provides additional information.