### PR TITLE
Upgrade to pydantic v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 [Pydantic](https://pydantic-docs.helpmanual.io/) models for the [Reasoner API](https://github.com/NCATS-Tangerine/NCATS-ReasonerStdAPI) data formats.
 
-These models are very handy when setting up a Reasoner API with [FastAPI](https://fastapi.tiangolo.com/). 
+These models are very handy when setting up a Reasoner API with [FastAPI](https://fastapi.tiangolo.com/).
 
-These models provide validation for TRAPI messages, as well as useful utilities based on architectural decisions, such as edge merging, result merging, and analysis combination. 
+These models provide validation for TRAPI messages, as well as useful utilities based on architectural decisions, such as edge merging, result merging, and analysis combination.
 
 ## Example usage
 
@@ -14,58 +14,77 @@ These models provide validation for TRAPI messages, as well as useful utilities 
 from reasoner_pydantic import (
     Query,
     Message,
-    QNode,
-    KnowledgeGraph,
     Node,
     Result,
-    NodeBinding,
+    CURIE,
 )
 
 
 def add_result_to_query(query_dict):
-    query = Query.parse_obj(query_dict)
+    query = Query.model_validate(query_dict)
     message: Message = query.message
 
     # get query graph node
     qnode_id = next(iter(message.query_graph.nodes))
 
     # add knowledge graph node
-    knode = Node.parse_obj({"categories": ["biolink:FooBar"]})
-    knode_id = "foo:bar"
+    knode = Node.model_validate({"categories": ["biolink:FooBar"]})
+    knode_id = CURIE("foo:bar")
     message.knowledge_graph.nodes[knode_id] = knode
 
     # add result
-    result: Result = Result.parse_obj(
-        {
-            "node_bindings": {qnode_id: [{"id": knode_id}]}
-        }
-    )
+    result: Result = Result.model_validate({"node_bindings": {qnode_id: [{"id": knode_id}]}})
 
     message.results.add(result)
 
-    return message.json()
+    return message.model_dump_json()
 
 
-add_result_to_query({
-    "message": {
-        "query_graph": {"nodes": {"n0": {}}, "edges": {}},
-        "knowledge_graph": {"nodes": {}, "edges": {}},
-        "results" : []
+add_result_to_query(
+    {
+        "message": {
+            "query_graph": {"nodes": {"n0": {}}, "edges": {}},
+            "knowledge_graph": {"nodes": {}, "edges": {}},
+            "results": [],
+        }
     }
-})
+)
 ```
 
 ## Validation Usage
 
-Because of performance concerns, as well as how types are implemented in Python, there is no assignment validation enforced on these models.
-For example:
+Typically, you'll want to instantiate models using `<ModelName>.model_validate(<data>)`:
 
 ```python
 from reasoner_pydantic import KnowledgeGraph
 
-# This will not throw an error
-kg = KnowledgeGraph(nodes = "hi")
+# In Python dict format
+kg = KnowledgeGraph.model_validate(<your kg dict here>)
+# In raw JSON
+kg = KnowledgeGraph.model_validate_json(<your kg JSON string here>)
 ```
+
+You can also directly instantiate models, however it's not quite as clean:
+
+```python
+from reasoner_pydantic import KnowledgeGraph
+
+kg = KnowledgeGraph(nodes=<your nodes here>, edges=<your edges here>)
+```
+
+In all of these cases, validation is automatically done. In most use-cases it's recommended to use `model_validate()` as the performance cost is much lower than in pydantic v1. However, if you're absolutely certain your data is valid, you can construct a model without validation:
+
+```python
+from reasoner_pydantci import KnowledgeGraph
+
+kg = KnowledgeGraph.model_construct(nodes="fake")
+# Won't throw errors
+```
+
+> [!WARNING]
+> All values passed to `model_construct()` will not be transformed into their appropriate models.
+> Pydantic's documentation states that it's often *more* performant to use `model_validate()`,
+> so it's highly recommended to avoid using this method.
 
 This is especially important to keep in mind when constructing objects that use containers.
 This library uses custom container types: HashableMapping, HashableSequence, HashableSet:
@@ -77,10 +96,10 @@ from reasoner_pydantic import KnowledgeGraph, Node, CURIE
 kg = KnowledgeGraph(nodes = {})
 
 # Instead, if you would like to build models this way, use a typed container constructor
-kg = KnowledgeGraph(nodes = HashableMapping[CURIE, Node](__root__ = {}))
+kg = KnowledgeGraph(nodes = HashableMapping[CURIE, Node]())
 ```
 
 For this reason, we recommend one of the following options:
 
-1. Use `parse_obj` exclusively for constructing models. This will perform validation for you. This option is best if performance is not important.
-2. Use a static type checker to ensure that models are being constructed correctly. Constructing objects this way is more performant, and the static type checker will ensure that it is done correctly. We recommend using [pyright](https://github.com/microsoft/pyright) in your editor.
+1. Use `model_validate()` exclusively for constructing models. This will perform validation for you. This option is best if performance is not important.
+1. Use a static type checker to ensure that models are being constructed correctly. Constructing objects this way is more performant, and the static type checker will ensure that it is done correctly. We recommend using [pyright](https://github.com/microsoft/pyright) in your editor.

--- a/docs/NORMALIZE.md
+++ b/docs/NORMALIZE.md
@@ -1,0 +1,15 @@
+# Edge ID Normalizing
+
+Typically, edge ids are normalized on Message/Response validation, or on updating one Message/Response with another.
+
+If you wish to avoid this:
+
+```python
+from reasoner_pydantic import Message
+
+# Avoid normalization on creation
+m = Message.model_validate(<your message dict>, context={"normalize": False})
+
+# Avoid normalization when updating:
+m.update(<your other message model>, normalize=False)
+```

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -22,6 +22,4 @@ def test_hash_property_update():
 
 To achieve this, we have a [custom base model](reasoner_pydantic/base_model.py) for all objects that includes a hash function. This hash function recurses down through the object and computes the hash for the entire object when called. We have similar code in place for lists, dicts, and sets, which can be found in the [reasoner_pydantic/utils.py](reasoner_pydantic/utils.py) file. When implemented properly, this provide the basis for efficient in-place object merging.
 
-These hashes are natively computed deterministically, so they can be used for purposes such as caching.
-
-
+To ensure deterministic hash values, it is required that the `PYTHONHASHSEED` environment variable be set to `0`.

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -22,6 +22,6 @@ def test_hash_property_update():
 
 To achieve this, we have a [custom base model](reasoner_pydantic/base_model.py) for all objects that includes a hash function. This hash function recurses down through the object and computes the hash for the entire object when called. We have similar code in place for lists, dicts, and sets, which can be found in the [reasoner_pydantic/utils.py](reasoner_pydantic/utils.py) file. When implemented properly, this provide the basis for efficient in-place object merging.
 
-To ensure deterministic hash values, it is required that the `PYTHONHASHSEED` environemntal variable be set to `0`.
+These hashes are natively computed deterministically, so they can be used for purposes such as caching.
 
 

--- a/reasoner_pydantic/__init__.py
+++ b/reasoner_pydantic/__init__.py
@@ -43,6 +43,8 @@ from .metakg import (
 )
 from .utils import (
     HashableSequence,
+    HashableMapping,
+    HashableSet,
 )
 
 components = [
@@ -81,4 +83,6 @@ components = [
     Workflow,
     Analysis,
     HashableSequence,
+    HashableMapping,
+    HashableSet,
 ]

--- a/reasoner_pydantic/auxgraphs.py
+++ b/reasoner_pydantic/auxgraphs.py
@@ -1,61 +1,48 @@
 """Auxiliary Graphs model"""
 
-from typing import Optional
-
-from pydantic import Field, parse_obj_as
+from typing import Annotated, Any
+from pydantic import ConfigDict, Field
 
 from .base_model import BaseModel
 from .utils import HashableMapping, HashableSet
-from .shared import Attribute, CURIE
+from .shared import Attribute, EdgeIdentifier
 
 
 class AuxiliaryGraph(BaseModel):
     """Auxiliary Graph"""
 
-    edges: HashableSet[str] = Field(..., title="edges in auxiliary graph")
+    edges: Annotated[
+        HashableSet[EdgeIdentifier], Field(title="edges in auxiliary graph")
+    ]
 
-    attributes: HashableSet[Attribute] = Field(..., nullable=False)
-
-    class Config:
-        title = "auxiliary graph"
-        extra = "allow"
+    attributes: HashableSet[Attribute]
+    model_config = ConfigDict(title="auxiliary graph", extra="allow")
 
 
-class AuxiliaryGraphs(BaseModel):
+class AuxiliaryGraphs(HashableMapping[str, AuxiliaryGraph]):
     """Auxiliary Graphs"""
 
-    __root__: Optional[HashableMapping[str, AuxiliaryGraph]]
+    model_config = ConfigDict(title="auxiliary graphs")
 
-    class Config:
-        title = "auxiliary graphs"
-        extra = "allow"
-
-    def update(self, other):
-        self.__root__.update(other.__root__)
+    def update(self, other: object, *_args: Any, **_kwargs: Any):
+        if not isinstance(other, HashableMapping):
+            raise TypeError("AuxiliaryGraphs may only be updated with AuxiliaryGraphs.")
+        self.root.update(other.root)
 
     def values(self):
-        return self.__root__.values()
+        return self.root.values()
 
     def items(self):
-        return self.__root__.items()
+        return self.root.items()
 
     def keys(self):
-        return self.__root__.keys()
+        return self.root.keys()
 
-    def __setitem__(self, k, v):
-        self.__root__[k] = v
+    def __setitem__(self, k: str, v: AuxiliaryGraph):
+        self.root[k] = v
 
-    def __getitem__(self, k):
-        return self.__root__[k]
+    def __getitem__(self, k: str):
+        return self.root[k]
 
     def __iter__(self):
-        return iter(self.__root__)
-
-    def parse_obj(obj):
-        auxiliary_graphs = parse_obj_as(AuxiliaryGraphs, obj)
-        graphs = AuxiliaryGraphs()
-        graphs.__root__ = HashableMapping[str, AuxiliaryGraph]()
-        for id, graph in obj.items():
-            graphs.__root__[id] = AuxiliaryGraph.parse_obj(graph)
-        graphs.update(auxiliary_graphs)
-        return graphs
+        return iter(self.root)

--- a/reasoner_pydantic/auxgraphs.py
+++ b/reasoner_pydantic/auxgraphs.py
@@ -14,8 +14,8 @@ class AuxiliaryGraph(BaseModel):
     edges: Annotated[
         HashableSet[EdgeIdentifier], Field(title="edges in auxiliary graph")
     ]
-
     attributes: HashableSet[Attribute]
+
     model_config = ConfigDict(title="auxiliary graph", extra="allow")
 
 

--- a/reasoner_pydantic/base_model.py
+++ b/reasoner_pydantic/base_model.py
@@ -1,5 +1,4 @@
-import json
-from typing import Any, Final, Generic, Self, TypeVar
+from typing import Any, Generic, TypeVar
 
 from pydantic import (
     model_validator,
@@ -42,7 +41,7 @@ class BaseModel(PydanticBaseModel):
         return getattr(self, field, None)
 
     @model_validator(mode="after")
-    def ensure_hashable_extra(self) -> Self:
+    def ensure_hashable_extra(self) -> "BaseModel":
         """Ensure extra fields are hashable, if they're allowed."""
         if not self.model_extra:
             return self

--- a/reasoner_pydantic/base_model.py
+++ b/reasoner_pydantic/base_model.py
@@ -7,7 +7,7 @@ from pydantic import (
     RootModel as PydanticRootModel,
 )
 
-from .utils import make_hashable, stable_hash
+from .utils import make_hashable
 
 
 class BaseModel(PydanticBaseModel):
@@ -17,20 +17,18 @@ class BaseModel(PydanticBaseModel):
     This provides hash and equality methods.
     """
 
-    _stable_hashable: Final[bool] = True
-
     def __hash__(self) -> int:
         """Hash function based on Pydantic implementation"""
-        return stable_hash(
+        return hash(
             (
                 self.__class__.__name__,
-                {
-                    k: stable_hash(v)
+                *(
+                    (k, hash(v))
                     for k, v in {
                         **self.__dict__,
                         **(self.__pydantic_extra__ or {}),
                     }.items()
-                },
+                ),
             )
         )
 

--- a/reasoner_pydantic/kgraph.py
+++ b/reasoner_pydantic/kgraph.py
@@ -14,7 +14,7 @@ from .shared import (
     ResourceRoleEnum,
 )
 from .base_model import BaseModel
-from .utils import HashableMapping, HashableSet, stable_hash
+from .utils import HashableMapping, HashableSet 
 
 
 class Node(BaseModel):
@@ -64,7 +64,7 @@ class RetrievalSource(BaseModel):
     source_record_urls: Optional[HashableSet[str]] = None
 
     def __hash__(self) -> int:
-        return stable_hash((self.resource_id, self.resource_role))
+        return hash((self.resource_id, self.resource_role))
 
     def update(self, other: object):
         if not isinstance(other, RetrievalSource):
@@ -102,12 +102,12 @@ class Edge(BaseModel):
 
     def __hash__(self) -> int:
         primary_knowledge_source = self.get_primary_knowedge_source()
-        return stable_hash(
+        return hash(
             (
                 self.subject,
                 self.object,
                 self.predicate,
-                hash(self.qualifiers) if self.qualifiers is not None else None,
+                self.qualifiers,
                 primary_knowledge_source,
             )
         )

--- a/reasoner_pydantic/kgraph.py
+++ b/reasoner_pydantic/kgraph.py
@@ -1,6 +1,6 @@
 """Knowledge graph models."""
 
-from typing import Annotated, Any, Optional, override
+from typing import Annotated, Any, Optional
 
 from pydantic import ConfigDict, Field
 

--- a/reasoner_pydantic/kgraph.py
+++ b/reasoner_pydantic/kgraph.py
@@ -14,7 +14,7 @@ from .shared import (
     ResourceRoleEnum,
 )
 from .base_model import BaseModel
-from .utils import HashableMapping, HashableSet 
+from .utils import HashableMapping, HashableSet
 
 
 class Node(BaseModel):

--- a/reasoner_pydantic/kgraph.py
+++ b/reasoner_pydantic/kgraph.py
@@ -24,6 +24,7 @@ class Node(BaseModel):
     name: Optional[str] = None
     attributes: HashableSet[Attribute]
     is_set: Optional[bool] = None
+
     model_config = ConfigDict(
         title="knowledge-graph node",
         json_schema_extra={
@@ -58,11 +59,8 @@ class RetrievalSource(BaseModel):
     """A component of source retrieval provenance"""
 
     resource_id: Annotated[CURIE, Field(title="infores for source")]
-
     resource_role: Annotated[ResourceRoleEnum, Field(title="source type")]
-
     upstream_resource_ids: Optional[HashableSet[CURIE]] = None
-
     source_record_urls: Optional[HashableSet[str]] = None
 
     def __hash__(self) -> int:
@@ -99,6 +97,7 @@ class Edge(BaseModel):
     ]
     qualifiers: Optional[HashableSet[Qualifier]] = None
     attributes: Optional[HashableSet[Attribute]]
+
     model_config = ConfigDict(title="knowledge-graph edge", extra="forbid")
 
     def update(self, other: Any):
@@ -156,6 +155,7 @@ class KnowledgeGraph(BaseModel):
     edges: HashableMapping[EdgeIdentifier, Edge] = Field(
         default_factory=lambda: HashableMapping[EdgeIdentifier, Edge]()
     )
+
     model_config = ConfigDict(title="knowledge graph", extra="allow")
 
     def update(self, other: object) -> None:

--- a/reasoner_pydantic/message.py
+++ b/reasoner_pydantic/message.py
@@ -30,9 +30,8 @@ from typing import Annotated
 class Message(BaseModel):
     """Message."""
 
-
     query_graph: Annotated[
-        Optional[Union[QueryGraph PathfinderQueryGraph]],
+        Optional[Union[QueryGraph, PathfinderQueryGraph]],
         Field(
             title="query graph",
         ),

--- a/reasoner_pydantic/message.py
+++ b/reasoner_pydantic/message.py
@@ -109,7 +109,7 @@ class Message(BaseModel):
         Replace edge IDs with a hash of the edge object
         """
         self._update_kg_edge_ids(
-            lambda edge: EdgeIdentifier.model_validate(
+            lambda edge: EdgeIdentifier(
                 hashlib.blake2b(
                     hash(edge).to_bytes(16, byteorder="big", signed=True), digest_size=6
                 ).hexdigest()

--- a/reasoner_pydantic/message.py
+++ b/reasoner_pydantic/message.py
@@ -6,7 +6,7 @@ import hashlib
 from typing import Optional, Callable, Union
 
 
-from .results import Result, Results, Analysis
+from .results import Results, Analysis
 from .qgraph import QueryGraph, PathfinderQueryGraph
 from pydantic import (
     AnyHttpUrl,
@@ -18,8 +18,6 @@ from pydantic import (
 
 from .base_model import BaseModel
 from .utils import HashableSequence
-from .results import Results
-from .qgraph import QueryGraph
 from .kgraph import Edge, KnowledgeGraph
 from .shared import EdgeIdentifier, LogEntry, LogLevel
 from .workflow import Workflow

--- a/reasoner_pydantic/message.py
+++ b/reasoner_pydantic/message.py
@@ -5,91 +5,80 @@ import hashlib
 
 from typing import Optional, Callable, Union
 
-from pydantic import constr, Field, parse_obj_as, validator, ValidationError
+
+from .results import Result, Results, Analysis
+from .qgraph import QueryGraph, PathfinderQueryGraph
+from pydantic import (
+    AnyHttpUrl,
+    ValidationInfo,
+    field_validator,
+    ConfigDict,
+    Field,
+    model_validator,
+)
 
 from .base_model import BaseModel
 from .utils import HashableSequence, HashableSet
-from .results import Result, Results, Analysis
-from .qgraph import QueryGraph, PathfinderQueryGraph
-from .kgraph import KnowledgeGraph
-from .shared import LogEntry, LogLevel
+from .results import Results
+from .qgraph import QueryGraph
+from .kgraph import Edge, KnowledgeGraph
+from .shared import EdgeIdentifier, LogEntry, LogLevel
 from .workflow import Workflow
 from .auxgraphs import AuxiliaryGraphs
+from typing import Annotated
 
 
 class Message(BaseModel):
     """Message."""
 
-    query_graph: Optional[Union[QueryGraph, PathfinderQueryGraph]] = Field(
-        None,
-        title="query graph",
-        nullable=True,
-    )
-    knowledge_graph: Optional[KnowledgeGraph] = Field(
-        None,
-        title="knowledge graph",
-        nullable=True,
-    )
-    results: Optional[Results] = Field(
-        None,
-        title="list of results",
-        nullable=True,
-    )
-    auxiliary_graphs: Optional[AuxiliaryGraphs] = Field(
-        None, title="dict of auxiliary graphs", nullable=True
-    )
 
-    class Config:
-        title = "message"
-        extra = "forbid"
+    query_graph: Annotated[
+        Optional[Union[QueryGraph PathfinderQueryGraph]],
+        Field(
+            title="query graph",
+        ),
+    ] = None
+    # query_graph: Optional[QueryGraph] = None
+    knowledge_graph: Annotated[
+        Optional[KnowledgeGraph],
+        Field(
+            title="knowledge graph",
+        ),
+    ] = None
+    results: Annotated[
+        Optional[Results],
+        Field(
+            title="list of results",
+        ),
+    ] = None
+    auxiliary_graphs: Annotated[
+        Optional[AuxiliaryGraphs],
+        Field(
+            title="dict of auxiliary graphs",
+        ),
+    ] = None
+    model_config = ConfigDict(title="message", extra="forbid")
 
-    def parse_obj(obj, normalize=True):
-        message = parse_obj_as(Message, obj)
-        qgraph = None
-        kgraph = None
-        results = None
-        auxgraphs = None
-        if "query_graph" in obj.keys() and obj["query_graph"] is not None:
-            if "edges" in obj["query_graph"].keys():
-                qgraph = QueryGraph.parse_obj(obj["query_graph"])
-            elif "paths" in obj["query_graph"].keys():
-                qgraph = PathfinderQueryGraph.parse_obj(obj["query_graph"])
-            else:
-                raise ValidationError(["No Paths or Edges in Query Graph"], Message)
-        if "knowledge_graph" in obj.keys() and obj["knowledge_graph"] is not None:
-            kgraph = KnowledgeGraph.parse_obj(obj["knowledge_graph"])
-        if "results" in obj.keys() and obj["results"] is not None:
-            results = Results.parse_obj(obj["results"])
-        if "auxiliary_graphs" in obj.keys() and obj["auxiliary_graphs"] is not None:
-            auxgraphs = AuxiliaryGraphs.parse_obj(obj["auxiliary_graphs"])
-        m = parse_obj_as(Message, {})
-        m.query_graph, m.knowledge_graph, m.results, m.auxiliary_graphs = (
-            qgraph,
-            kgraph,
-            results,
-            auxgraphs,
-        )
-        if m.knowledge_graph and normalize:
-            m._normalize_kg_edge_ids()
-        return m
-
-    def update(self, other: "Message", normalize=True):
+    def update(self, other: object, normalize: bool = True) -> None:
         """Updates one message with information from another.
         Can run with normalize=false, if both messages are normalized already."""
+        if not isinstance(other, Message):
+            raise TypeError("Message may only be updated with another Message.")
+
         if hash(self.query_graph) != hash(other.query_graph):
             raise NotImplementedError("Query graph merging not supported yet")
         # Make a copy because normalization will modify results
-        other = other.copy(deep=True)
+        other = other.model_copy(deep=True)
 
         if other.knowledge_graph:
             if not self.knowledge_graph:
-                self.knowledge_graph = KnowledgeGraph(nodes=[], edges=[])
+                self.knowledge_graph = KnowledgeGraph()
             # Normalize edges of incoming KG
             # This will place KG edge keys into the same hashing system
             # So that equivalence is determined by hash collision
             if normalize:
                 other._normalize_kg_edge_ids()
-            # The knowledge graph can now be udated because edge keys will be
+            # The knowledge graph can now be updated because edge keys will be
             # hashed using the same method. The knowledge graph update method
             # will handle concatenating properties when necessary.
             self.knowledge_graph.update(other.knowledge_graph)
@@ -104,23 +93,40 @@ class Message(BaseModel):
             else:
                 self.auxiliary_graphs = other.auxiliary_graphs
 
-    def _normalize_kg_edge_ids(self):
+    @model_validator(mode="after")
+    def normalize_on_parse(self, info: ValidationInfo) -> "Message":
+        normalize = True
+        if isinstance(info.context, dict) and not info.context.get("normalize", True):
+            normalize = False
+        if normalize and self.knowledge_graph is not None:
+            self._normalize_kg_edge_ids()
+        return self
+
+    def normalize(self) -> None:
+        self._normalize_kg_edge_ids()
+
+    def _normalize_kg_edge_ids(self) -> None:
         """
         Replace edge IDs with a hash of the edge object
         """
         self._update_kg_edge_ids(
-            lambda edge: hashlib.blake2b(
-                hash(edge).to_bytes(16, byteorder="big", signed=True), digest_size=6
-            ).hexdigest(),
+            lambda edge: EdgeIdentifier.model_validate(
+                hashlib.blake2b(
+                    hash(edge).to_bytes(16, byteorder="big", signed=True), digest_size=6
+                ).hexdigest()
+            )
         )
 
-    def _update_kg_edge_ids(self, update_func: Callable):
+    def _update_kg_edge_ids(self, update_func: Callable[[Edge], EdgeIdentifier]):
         """
         Replace edge IDs using the specified function
         """
 
+        if self.knowledge_graph is None:
+            return
+
         # Mapping of old to new edge IDs
-        edge_id_mapping = {}
+        edge_id_mapping: dict[EdgeIdentifier, EdgeIdentifier] = {}
 
         # Make a copy of the edge keys because we're about to change them
         for edge_id in list(self.knowledge_graph.edges.keys()):
@@ -156,9 +162,9 @@ class Message(BaseModel):
                     if edges_len != edges_num:
                         raise Exception("Missed an aux graph edge normalization.")
                 else:
-                    raise Exception(f"This aux graph has no edges")
+                    raise Exception("This aux graph has no edges")
             if aux_len != aux_num:
-                raise Exception(f"Missed an aux graph normalization.")
+                raise Exception("Missed an aux graph normalization.")
 
         # Update results
         if self.results:
@@ -174,94 +180,76 @@ class Message(BaseModel):
 class Query(BaseModel):
     """Request."""
 
-    message: Message = Field(
-        ...,
-        title="message",
+    message: Message
+    log_level: Optional[LogLevel] = None
+    workflow: Optional[Workflow] = None
+    bypass_cache: Optional[bool] = None
+    model_config = ConfigDict(
+        title="query", extra="allow", json_schema_extra={"x-body-name": "request_body"}
     )
-    log_level: Optional[LogLevel] = Field(
-        None,
-        title="log_level",
-        nullable=True,
-    )
-    workflow: Optional[Workflow]
-    bypass_cache: Optional[bool]
-
-    class Config:
-        title = "query"
-        extra = "allow"
-        schema_extra = {"x-body-name": "request_body"}
 
 
 class AsyncQuery(BaseModel):
     """AsyncQuery."""
 
-    callback: constr(regex=r"^https?://") = Field(..., format="uri", nullable=False)
-    message: Message = Field(..., title="message", nullable=False)
-    log_level: Optional[LogLevel] = Field(
-        None,
-        title="log_level",
-        nullable=True,
+    callback: AnyHttpUrl
+    message: Message
+    log_level: Optional[LogLevel] = None
+    workflow: Optional[Workflow] = None
+    bypass_cache: Optional[bool] = None
+    model_config = ConfigDict(
+        title="query", extra="allow", json_schema_extra={"x-body-name": "request_body"}
     )
-    workflow: Optional[Workflow]
-    bypass_cache: Optional[bool]
-
-    class Config:
-        title = "query"
-        extra = "allow"
-        schema_extra = {"x-body-name": "request_body"}
 
 
 class Response(BaseModel):
     """Response."""
 
-    message: Message = Field(..., title="message", nullable=False)
+    message: Message
 
-    logs: Optional[HashableSequence[LogEntry]] = Field([], nullable=False)
+    logs: Optional[HashableSequence[LogEntry]] = Field(
+        default_factory=lambda: HashableSequence[LogEntry]()
+    )
+    status: Optional[str] = None
 
-    status: Optional[str] = Field(None, nullable=True)
+    workflow: Optional[Workflow] = None
+    model_config = ConfigDict(title="response", extra="allow")
 
-    workflow: Optional[Workflow]
-
-    class Config:
-        title = "response"
-        extra = "allow"
-
-    @validator("logs")
-    def prevent_none(cls, v):
+    @field_validator("logs")
+    @classmethod
+    def prevent_none(cls, v: object):
         assert v is not None
         return v
 
-    def parse_obj(obj, normalize=True):
-        response = parse_obj_as(Response, obj)
-        response.message = Message.parse_obj(obj["message"], normalize)
-        return response
+    @model_validator(mode="after")
+    def normalize(self, info: ValidationInfo) -> "Response":
+        normalize = True
+        if isinstance(info.context, dict) and not info.context.get("normalize", True):
+            normalize = False
+        if normalize and self.message.knowledge_graph is not None:
+            self.message.normalize()
+        return self
 
 
 class AsyncQueryResponse(BaseModel):
     """ "Async Query Response."""
 
-    status: Optional[str] = Field(None, nullable=True)
+    status: Optional[str] = None
 
-    description: Optional[str] = Field(None, nullable=True)
+    description: Optional[str] = None
 
-    job_id: str = Field(..., title="job id")
-
-    class Config:
-        title = "async query response"
-        extra = "allow"
+    job_id: Annotated[str, Field(title="job id")]
+    model_config = ConfigDict(title="async query response", extra="allow")
 
 
 class AsyncQueryStatusResponse(BaseModel):
     """Async Query Status Response."""
 
-    status: str = Field(..., title="status")
+    status: str
 
-    description: str = Field(..., title="description")
+    description: str
 
-    logs: HashableSet[LogEntry] = Field(..., nullable=False)
+    logs: HashableSet[LogEntry]
 
-    response_url: Optional[str] = Field(None, nullable=True)
-
-    class Config:
-        title = "async query status response"
-        extra = "allow"
+    response_url: Optional[str] = None
+    model_config = ConfigDict(title="async query status response", extra="allow")

--- a/reasoner_pydantic/message.py
+++ b/reasoner_pydantic/message.py
@@ -211,7 +211,7 @@ class Response(BaseModel):
     status: Optional[str] = None
     description: Optional[str] = None
     workflow: Optional[Workflow] = None
-    schema_verison: Optional[str] = None
+    schema_version: Optional[str] = None
     biolink_version: Optional[str] = None
 
     model_config = ConfigDict(title="response", extra="allow")

--- a/reasoner_pydantic/metakg.py
+++ b/reasoner_pydantic/metakg.py
@@ -1,8 +1,8 @@
-from pydantic import validator
+from pydantic import AfterValidator, ConfigDict
 from reasoner_pydantic.shared import CURIE, KnowledgeType
-from typing import Optional
+from typing import Annotated, Optional
 
-from reasoner_pydantic import BiolinkEntity, BiolinkPredicate, BiolinkQualifier
+from reasoner_pydantic import BiolinkEntity, BiolinkPredicate
 
 from .base_model import BaseModel
 from .utils import HashableMapping, HashableSequence, nonzero_validator
@@ -12,37 +12,32 @@ class MetaAttribute(BaseModel):
     """MetaAttribute."""
 
     attribute_type_id: CURIE
-    attribute_source: Optional[str]
-    original_attribute_names: Optional[HashableSequence[str]]
+    attribute_source: Optional[str] = None
+    original_attribute_names: Optional[HashableSequence[str]] = None
     constraint_use: Optional[bool] = False
-    constraint_name: Optional[str]
+    constraint_name: Optional[str] = None
 
 
 class MetaNode(BaseModel):
-    id_prefixes: HashableSequence[str]
-    _nonzero_id_prefixes = validator("id_prefixes", allow_reuse=True)(nonzero_validator)
-    attributes: Optional[HashableSequence[MetaAttribute]]
-
-    class Config:
-        extra = "forbid"
+    id_prefixes: Annotated[HashableSequence[str], AfterValidator(nonzero_validator)]
+    attributes: Optional[HashableSequence[MetaAttribute]] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class MetaQualifier(BaseModel):
     qualifier_type_id: CURIE
-    applicable_values: Optional[HashableSequence[str]]
+    applicable_values: Optional[HashableSequence[str]] = None
 
 
 class MetaEdge(BaseModel):
     subject: BiolinkEntity
     predicate: BiolinkPredicate
     object: BiolinkEntity
-    qualifiers: Optional[HashableSequence[MetaQualifier]]
-    attributes: Optional[HashableSequence[MetaAttribute]]
-    knowledge_types: Optional[HashableSequence[KnowledgeType]]
-    association: Optional[BiolinkEntity]
-
-    class Config:
-        extra = "forbid"
+    qualifiers: Optional[HashableSequence[MetaQualifier]] = None
+    attributes: Optional[HashableSequence[MetaAttribute]] = None
+    knowledge_types: Optional[HashableSequence[KnowledgeType]] = None
+    association: Optional[BiolinkEntity] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class MetaKnowledgeGraph(BaseModel):

--- a/reasoner_pydantic/qgraph.py
+++ b/reasoner_pydantic/qgraph.py
@@ -59,10 +59,9 @@ class QualifierConstraint(BaseModel):
 class PathConstraint(BaseModel):
     """QPath Constraint."""
 
-    intermediate_categories: Optional[HashableSequence[BiolinkEntity]]
-    _nonzero_categories = validator("intermediate_categories", allow_reuse=True)(
-        nonzero_validator
-    )
+    intermediate_categories: Annotated[
+        Optional[HashableSequence[BiolinkEntity]], AfterValidator(nonzero_validator)
+    ]
 
 
 class SetInterpretationEnum(str, Enum):
@@ -141,24 +140,24 @@ class QPath(BaseModel):
     """Query path."""
 
     subject: Annotated[
-        str, 
+        str,
         Field(
             title="subject node id",
-        )
+        ),
     ]
 
     object: Annotated[
-        str, 
+        str,
         Field(
             title="object node id",
-        )
+        ),
     ]
 
     predicates: Annotated[
         Optional[HashableSequence[BiolinkPredicate]],
         Field(
             title="predicates",
-        )
+        ),
     ] = None
 
     constraints: Optional[HashableSequence[PathConstraint]]
@@ -197,7 +196,7 @@ class PathfinderQueryGraph(BaseQueryGraph):
         HashableMapping[str, QPath],
         Field(
             title="dict of paths",
-        )
+        ),
     ]
 
     model_config = ConfigDict(title="pathfinder query graph", extra="allow")

--- a/reasoner_pydantic/qgraph.py
+++ b/reasoner_pydantic/qgraph.py
@@ -51,12 +51,9 @@ class AttributeConstraint(BaseModel):
 class QualifierConstraint(BaseModel):
     """QEdge Qualifier constraint."""
 
-    qualifier_set: Annotated[
-        HashableSequence[Qualifier],
-        Field(
-            title="qualifier set",
-        ),
-    ] = HashableSequence[Qualifier]()
+    qualifier_set: HashableSequence[Qualifier] = Field(
+        title="qualifier set", default_factory=lambda: HashableSequence[Qualifier]()
+    )
 
 
 class PathConstraint(BaseModel):
@@ -82,25 +79,20 @@ class QNode(BaseModel):
     ids: Annotated[
         Optional[HashableSequence[CURIE]], AfterValidator(nonzero_validator)
     ] = None
-
     categories: Annotated[
         Optional[HashableSequence[BiolinkEntity]], AfterValidator(nonzero_validator)
     ] = None
-
     set_interpretation: Annotated[
         Optional[SetInterpretationEnum], Field(SetInterpretationEnum.BATCH)
     ]
+    constraints: HashableSequence[AttributeConstraint] = Field(
+        title="attribute constraints",
+        default_factory=lambda: HashableSequence[AttributeConstraint](),
+    )
+    member_ids: Optional[HashableSequence[CURIE]] = Field(
+        title="set member ids", default_factory=lambda: HashableSequence[CURIE]()
+    )
 
-    constraints: Annotated[
-        Optional[HashableSequence[AttributeConstraint]],
-        Field(
-            title="attribute constraints",
-        ),
-    ] = HashableSequence[AttributeConstraint]()
-
-    member_ids: Annotated[
-        Optional[HashableSequence[CURIE]], Field(title="set member ids")
-    ] = HashableSequence[CURIE]()
     model_config = ConfigDict(
         title="query-graph node",
         extra="allow",
@@ -125,28 +117,21 @@ class QEdge(BaseModel):
             title="object node id",
         ),
     ]
-
     knowledge_type: Annotated[
         Optional[KnowledgeType], Field(title="knowledge type")
     ] = None
-
     predicates: Annotated[
         Optional[HashableSequence[BiolinkPredicate]], AfterValidator(nonzero_validator)
     ] = None
+    attribute_constraints: HashableSequence[AttributeConstraint] = Field(
+        title="attribute constraints",
+        default_factory=lambda: HashableSequence[AttributeConstraint](),
+    )
+    qualifier_constraints: HashableSequence[QualifierConstraint] = Field(
+        title="qualifier constraint",
+        default_factory=lambda: HashableSequence[QualifierConstraint](),
+    )
 
-    attribute_constraints: Annotated[
-        Optional[HashableSequence[AttributeConstraint]],
-        Field(
-            title="attribute constraints",
-        ),
-    ] = HashableSequence[AttributeConstraint]()
-
-    qualifier_constraints: Annotated[
-        Optional[HashableSequence[QualifierConstraint]],
-        Field(
-            title="qualifier constraint",
-        ),
-    ] = HashableSequence[QualifierConstraint]()
     model_config = ConfigDict(
         title="query-graph edge", extra="allow", populate_by_name=True
     )
@@ -208,9 +193,11 @@ class QueryGraph(BaseQueryGraph):
 class PathfinderQueryGraph(BaseQueryGraph):
     """Pathfinder query graph."""
 
-    paths: HashableMapping[str, QPath] = Field(
-        ...,
-        title="dict of paths",
-    )
+    paths: Annotated[
+        HashableMapping[str, QPath],
+        Field(
+            title="dict of paths",
+        )
+    ]
 
-    model_config = ConfigDict(title="simple query graph", extra="allow")
+    model_config = ConfigDict(title="pathfinder query graph", extra="allow")

--- a/reasoner_pydantic/results.py
+++ b/reasoner_pydantic/results.py
@@ -6,7 +6,7 @@ from typing import Annotated, Optional, Union
 from pydantic import ConfigDict, Field, model_validator
 
 from .base_model import BaseModel
-from .utils import HashableMapping, HashableSet, HashableSequence, stable_hash
+from .utils import HashableMapping, HashableSet, HashableSequence 
 from .shared import Attribute, CURIE, EdgeIdentifier
 
 
@@ -74,12 +74,12 @@ class Analysis(BaseAnalysis):
     model_config = ConfigDict(title="standard analysis", extra="allow")
 
     def __hash__(self) -> int:
-        return stable_hash(
+        return hash(
             (
                 self.resource_id,
-                hash(self.edge_bindings),
+                self.edge_bindings,
                 self.score,
-                hash(self.support_graphs) if self.support_graphs is not None else None,
+                self.support_graphs,
                 self.scoring_method,
             )
         )
@@ -203,7 +203,7 @@ class Result(BaseModel):
                 self.analyses = other.analyses
 
     def __hash__(self) -> int:
-        return stable_hash(self.node_bindings)
+        return hash(self.node_bindings)
 
     def combine_analyses_by_resource_id(self):
         # Useful when a service unintentionally adds multiple analyses to a single result

--- a/reasoner_pydantic/results.py
+++ b/reasoner_pydantic/results.py
@@ -27,6 +27,29 @@ class EdgeBinding(BaseModel):
     )
 
 
+class NodeBinding(BaseModel):
+    """Node binding."""
+
+    id: Annotated[
+        CURIE,
+        Field(
+            title="knowledge graph id",
+        ),
+    ]
+    query_id: Annotated[Optional[CURIE], Field(title="query graph id")] = None
+    attributes: HashableSet[Attribute]
+
+    model_config = ConfigDict(
+        title="node binding",
+        json_schema_extra={
+            "example": {
+                "id": "x:string",
+            },
+        },
+        extra="allow",
+    )
+
+
 class PathBinding(BaseModel):
     """Path binding."""
 
@@ -34,8 +57,8 @@ class PathBinding(BaseModel):
 
     model_config = ConfigDict(
         title="path binding",
-        json_schema_extra={ "example": {"id": "string"} }
-        extra="allow"
+        json_schema_extra={"example": {"id": "string"}},
+        extra="allow",
     )
 
 
@@ -49,12 +72,6 @@ class BaseAnalysis(BaseModel):
         ),
     ]
 
-    edge_bindings: Annotated[
-        HashableMapping[str, HashableSet[EdgeBinding]],
-        Field(
-            title="list of edge bindings",
-        ),
-    ]
     score: Optional[float] = None
     support_graphs: Optional[HashableSet[str]] = None
     scoring_method: Optional[str] = None
@@ -111,7 +128,7 @@ class PathfinderAnalysis(BaseAnalysis):
         HashableMapping[str, HashableSet[PathBinding]],
         Field(
             title="list of path bindings",
-        )
+        ),
     ]
 
     model_config = ConfigDict(title="pathfinder analysis", extra="allow")
@@ -143,29 +160,6 @@ class PathfinderAnalysis(BaseAnalysis):
                 self.support_graphs.update(other.support_graphs)
             else:
                 self.support_graphs = other.support_graphs
-
-
-class NodeBinding(BaseModel):
-    """Node binding."""
-
-    id: Annotated[
-        CURIE,
-        Field(
-            title="knowledge graph id",
-        ),
-    ]
-    query_id: Annotated[Optional[CURIE], Field(title="query graph id")] = None
-    attributes: HashableSet[Attribute]
-
-    model_config = ConfigDict(
-        title="node binding",
-        json_schema_extra={
-            "example": {
-                "id": "x:string",
-            },
-        },
-        extra="allow",
-    )
 
 
 class Result(BaseModel):

--- a/reasoner_pydantic/results.py
+++ b/reasoner_pydantic/results.py
@@ -14,8 +14,8 @@ class EdgeBinding(BaseModel):
     """Edge binding."""
 
     id: Annotated[EdgeIdentifier, Field(title="knowledge graph id")]
-
     attributes: HashableSet[Attribute]
+
     model_config = ConfigDict(
         title="edge binding",
         json_schema_extra={
@@ -30,16 +30,13 @@ class EdgeBinding(BaseModel):
 class PathBinding(BaseModel):
     """Path binding."""
 
-    id: str = Field(..., title="auxiliary graph id", nullable=False)
+    id: Annotated[str, Field(title="auxiliary graph id")]
 
-    class Config:
-        title = "path binding"
-        schema_extra = {
-            "example": {
-                "id": "string",
-            },
-        }
-        extra = "allow"
+    model_config = ConfigDict(
+        title="path binding",
+        json_schema_extra={ "example": {"id": "string"} }
+        extra="allow"
+    )
 
 
 class BaseAnalysis(BaseModel):
@@ -52,13 +49,15 @@ class BaseAnalysis(BaseModel):
         ),
     ]
 
-
+    edge_bindings: Annotated[
+        HashableMapping[str, HashableSet[EdgeBinding]],
+        Field(
+            title="list of edge bindings",
+        ),
+    ]
     score: Optional[float] = None
-
     support_graphs: Optional[HashableSet[str]] = None
-
     scoring_method: Optional[str] = None
-
     attributes: Optional[HashableSet[Attribute]] = None
 
 
@@ -155,10 +154,9 @@ class NodeBinding(BaseModel):
             title="knowledge graph id",
         ),
     ]
-
     query_id: Annotated[Optional[CURIE], Field(title="query graph id")] = None
-
     attributes: HashableSet[Attribute]
+
     model_config = ConfigDict(
         title="node binding",
         json_schema_extra={
@@ -179,13 +177,13 @@ class Result(BaseModel):
             title="list of node bindings",
         ),
     ]
-
     analyses: Annotated[
         Union[HashableSet[Analysis], HashableSet[PathfinderAnalysis]],
         Field(
             title="list of anlysis blocks",
         ),
     ]
+
     model_config = ConfigDict(title="result", extra="allow")
 
     def update(self, other: object):

--- a/reasoner_pydantic/results.py
+++ b/reasoner_pydantic/results.py
@@ -6,7 +6,7 @@ from typing import Annotated, Optional, Union
 from pydantic import ConfigDict, Field, model_validator
 
 from .base_model import BaseModel
-from .utils import HashableMapping, HashableSet, HashableSequence 
+from .utils import HashableMapping, HashableSet, HashableSequence
 from .shared import Attribute, CURIE, EdgeIdentifier
 
 

--- a/reasoner_pydantic/shared.py
+++ b/reasoner_pydantic/shared.py
@@ -109,8 +109,8 @@ class LogLevel(RootModel[LogLevelEnum]):
 class LogEntry(BaseModel):
     """Log entry."""
 
-    timestamp: Annotated[Optional[datetime], Field(default=None)]
-    level: Annotated[Optional[LogLevel], Field(default=None)]
-    code: Annotated[Optional[str], Field(default=None)]
-    message: Annotated[Optional[str], Field(default=None)]
+    timestamp: Optional[datetime] = None
+    level: Optional[LogLevel] = None
+    code: Optional[str] = None
+    message: str = ""
     model_config = ConfigDict(extra="allow")

--- a/reasoner_pydantic/shared.py
+++ b/reasoner_pydantic/shared.py
@@ -10,8 +10,8 @@ from typing import Annotated, Any, Optional
 from pydantic import ConfigDict, Field
 from pydantic.types import StringConstraints
 
-from .base_model import BaseModel, RootModel
-from .utils import HashableSequence, stable_hash
+from .base_model import BaseModel
+from .utils import HashableSequence
 
 
 # TODO: potential add validation for structure of CURIE

--- a/reasoner_pydantic/shared.py
+++ b/reasoner_pydantic/shared.py
@@ -14,27 +14,8 @@ from .base_model import BaseModel, RootModel
 from .utils import HashableSequence, stable_hash
 
 
-class StrValue(RootModel[str]):
-    """Generic handling for string values that supports equality with normal strings."""
-
-    root: str
-
-    def __eq__(self, other: object) -> bool:
-        return self.root == other.__str__()
-
-    def __hash__(self) -> int:
-        return stable_hash(self.root)
-
-    def __str__(self) -> str:
-        return self.root
-
-    def __json__(self) -> str:
-        return self.root
-
-
 # TODO: potential add validation for structure of CURIE
-class CURIE(StrValue):
-    """Compact URI."""
+CURIE = str
 
 
 class ResourceRoleEnum(str, Enum):
@@ -52,8 +33,7 @@ class KnowledgeType(str, Enum):
     inferred = "inferred"
 
 
-class EdgeIdentifier(StrValue):
-    """Identifier for an edge in a knowledge graph"""
+EdgeIdentifier = str
 
 
 class Attribute(BaseModel):

--- a/reasoner_pydantic/shared.py
+++ b/reasoner_pydantic/shared.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from datetime import datetime
 from enum import Enum
-from typing import Annotated, Any, Hashable, Optional
+from typing import Annotated, Hashable, Optional
 
 from pydantic import BeforeValidator, ConfigDict, Field
 from pydantic.types import StringConstraints

--- a/reasoner_pydantic/shared.py
+++ b/reasoner_pydantic/shared.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import re
 from datetime import datetime
 from enum import Enum
-from typing import Annotated, Any, Optional
+from typing import Annotated, Any, Hashable, Optional
 
-from pydantic import ConfigDict, Field
+from pydantic import BeforeValidator, ConfigDict, Field
 from pydantic.types import StringConstraints
 
 from .base_model import BaseModel
-from .utils import HashableSequence
+from .utils import HashableSequence, make_hashable
 
 
 # TODO: potential add validation for structure of CURIE
@@ -40,7 +40,7 @@ class Attribute(BaseModel):
     """Node/edge attribute."""
 
     attribute_type_id: Annotated[CURIE, Field(title="type")]
-    value: Any
+    value: Annotated[Hashable, BeforeValidator(make_hashable)]
     value_type_id: Optional[CURIE] = None
     original_attribute_name: Optional[str] = None
     value_url: Optional[str] = None

--- a/reasoner_pydantic/shared.py
+++ b/reasoner_pydantic/shared.py
@@ -91,19 +91,13 @@ BiolinkEntity = Annotated[
 ]
 
 
-class LogLevelEnum(str, Enum):
+class LogLevel(str, Enum):
     """Log level."""
 
-    error = "ERROR"
-    warning = "WARNING"
-    info = "INFO"
-    debug = "DEBUG"
-
-
-class LogLevel(RootModel[LogLevelEnum]):
-    """Log level."""
-
-    root: LogLevelEnum
+    ERROR = "ERROR"
+    WARNING = "WARNING"
+    INFO = "INFO"
+    DEBUG = "DEBUG"
 
 
 class LogEntry(BaseModel):

--- a/reasoner_pydantic/utils.py
+++ b/reasoner_pydantic/utils.py
@@ -164,12 +164,12 @@ def make_hashable(o: object):
     o_type = str(type(o))
 
     if "dict" in o_type:
-        return HashableMapping.model_validate(
+        return HashableMapping(
             {k: make_hashable(v) for k, v in cast(dict[Any, Any], o).items()}
         )
     if "list" in o_type:
-        return HashableSequence.model_validate(
-            (make_hashable(v) for v in cast(list[Any], o))
+        return HashableSequence(
+            [make_hashable(v) for v in cast(list[Any], o)]
         )
 
     return o

--- a/reasoner_pydantic/utils.py
+++ b/reasoner_pydantic/utils.py
@@ -1,7 +1,5 @@
 import collections.abc
-import hashlib
-import json
-from typing import Any, Collection, Final, Generic, Iterable, Optional, TypeVar, cast
+from typing import Any, Collection, Generic, Iterable, Optional, TypeVar, cast
 
 from pydantic import RootModel, model_serializer
 

--- a/reasoner_pydantic/workflow.py
+++ b/reasoner_pydantic/workflow.py
@@ -1,174 +1,135 @@
 """Operations models."""
 
 from enum import Enum
-from typing import Any, Optional, Union
-from pydantic.class_validators import validator
+from typing import Any, Literal, Optional, Union
 
-from pydantic.types import confloat, conint
 
-from .base_model import BaseModel
-from .utils import HashableSequence, nonzero_validator
+from .base_model import BaseModel, RootModel
+from .utils import HashableSequence
 from .shared import BiolinkPredicate
-
-
-def constant(s: str):
-    """Generate a static enum."""
-    return Enum(value=s, names={s: s}, type=str)
+from pydantic import Field, ConfigDict
+from typing import Annotated
 
 
 class RunnerAllowList(BaseModel):
-    allowlist: Optional[HashableSequence[str]]
-    timeout: Optional[float]
-
-    class Config:
-        extra = "forbid"
+    allowlist: Optional[HashableSequence[str]] = None
+    timeout: Optional[float] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class RunnerDenyList(BaseModel):
-    denylist: Optional[HashableSequence[str]]
-    timeout: Optional[float]
-
-    class Config:
-        extra = "forbid"
+    denylist: Optional[HashableSequence[str]] = None
+    timeout: Optional[float] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class RunnerTimeout(BaseModel):
-    timeout: Optional[float]
-
-    class Config:
-        extra = "forbid"
+    timeout: Optional[float] = None
+    model_config = ConfigDict(extra="forbid")
 
 
-class RunnerParameters(BaseModel):
-    __root__: Optional[Union[RunnerAllowList, RunnerDenyList, RunnerTimeout]]
+RunnerParameters = RootModel[
+    Optional[Union[RunnerAllowList, RunnerDenyList, RunnerTimeout]]
+]
 
 
 class BaseOperation(BaseModel):
-    runner_parameters: Optional[RunnerParameters]
-
-    class Config:
-        extra = "forbid"
+    runner_parameters: Optional[RunnerParameters] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class OperationAnnotate(BaseOperation):
-    id: constant("annotate")
-    parameters: Optional[Any]
-
-    class Config:
-        extra = "forbid"
+    id: Literal["annotate"]
+    parameters: Optional[Any] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class AnnotateEdgesParameters(BaseModel):
-    attributes: Optional[HashableSequence[str]]
+    attributes: Optional[HashableSequence[str]] = None
 
 
 class OperationAnnotateEdges(BaseOperation):
-    id: constant("annotate_edges")
-    parameters: Optional[AnnotateEdgesParameters]
-
-    class Config:
-        extra = "forbid"
+    id: Literal["annotate_edges"]
+    parameters: Optional[AnnotateEdgesParameters] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class AnnotateNodesParameters(BaseModel):
-    attributes: Optional[HashableSequence[str]]
+    attributes: Optional[HashableSequence[str]] = None
 
 
 class OperationAnnotateNodes(BaseOperation):
-    id: constant("annotate_nodes")
-    parameters: Optional[AnnotateNodesParameters]
-
-    class Config:
-        extra = "forbid"
+    id: Literal["annotate_nodes"]
+    parameters: Optional[AnnotateNodesParameters] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class OperationBind(BaseOperation):
-    id: constant("bind")
-    parameters: Optional[Any]
-
-    class Config:
-        extra = "forbid"
+    id: Literal["bind"]
+    parameters: Optional[Any] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class OperationCompleteResults(BaseOperation):
-    id: constant("complete_results")
-    parameters: Optional[Any]
-
-    class Config:
-        extra = "forbid"
+    id: Literal["complete_results"]
+    parameters: Optional[Any] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class EnrichResultsParameters(BaseModel):
-    pvalue_threshold: confloat(ge=0.0, le=1.0) = 1e-6
-    qnode_keys: Optional[HashableSequence[str]]
-    predicates_to_exclude: Optional[HashableSequence[BiolinkPredicate]]
+    pvalue_threshold: Annotated[float, Field(ge=0.0, le=1.0)] = 1e-6
+    qnode_keys: Optional[HashableSequence[str]] = None
+    predicates_to_exclude: Optional[HashableSequence[BiolinkPredicate]] = None
 
 
 class OperationEnrichResults(BaseOperation):
-    id: constant("enrich_results")
-    parameters: Optional[EnrichResultsParameters]
-
-    class Config:
-        extra = "forbid"
+    id: Literal["enrich_results"]
+    parameters: Optional[EnrichResultsParameters] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class FillAllowParameters(BaseModel):
-    allowlist: Optional[HashableSequence[str]]
-    qedge_keys: Optional[HashableSequence[str]]
-
-    class Config:
-        extra = "forbid"
+    allowlist: Optional[HashableSequence[str]] = None
+    qedge_keys: Optional[HashableSequence[str]] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class FillDenyParameters(BaseModel):
-    denylist: Optional[HashableSequence[str]]
-    qedge_keys: Optional[HashableSequence[str]]
-
-    class Config:
-        extra = "forbid"
+    denylist: Optional[HashableSequence[str]] = None
+    qedge_keys: Optional[HashableSequence[str]] = None
+    model_config = ConfigDict(extra="forbid")
 
 
-class FillParameters(BaseModel):
-    __root__: Union[FillAllowParameters, FillDenyParameters]
+FillParameters = RootModel[Union[FillAllowParameters, FillDenyParameters]]
 
 
 class OperationFill(BaseOperation):
-    id: constant("fill")
-    parameters: Optional[FillParameters]
-
-    class Config:
-        extra = "forbid"
+    id: Literal["fill"]
+    parameters: Optional[FillParameters] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class OperationFilterResults(BaseOperation):
-    id: constant("filter_results")
-    parameters: Optional[Any]
-
-    class Config:
-        extra = "forbid"
+    id: Literal["filter_results"]
+    parameters: Optional[Any] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class FilterResultsTopNParameters(BaseModel):
-    max_results: conint(ge=0)
-
-    class Config:
-        extra = "forbid"
+    max_results: Annotated[int, Field(ge=0)]
+    model_config = ConfigDict(extra="forbid")
 
 
 class OperationFilterResultsTopN(BaseOperation):
-    id: constant("filter_results_top_n")
-    parameters: Optional[FilterResultsTopNParameters]
-
-    class Config:
-        extra = "forbid"
+    id: Literal["filter_results_top_n"]
+    parameters: Optional[FilterResultsTopNParameters] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class OperationFilterKgraph(BaseOperation):
-    id: constant("filter_kgraph")
-    parameters: Optional[Any]
-
-    class Config:
-        extra = "forbid"
+    id: Literal["filter_kgraph"]
+    parameters: Optional[Any] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class AboveOrBelowEnum(str, Enum):
@@ -182,53 +143,49 @@ class FilterKgraphContinuousKedgeAttributeParameters(BaseModel):
     edge_attribute: str
     threshold: float
     remove_above_or_below: AboveOrBelowEnum
-    qedge_keys: Optional[HashableSequence[str]]
-    qnode_keys: HashableSequence[str] = []
+    qedge_keys: Optional[HashableSequence[str]] = None
+    qnode_keys: HashableSequence[str] = Field(
+        default_factory=lambda: HashableSequence[str]()
+    )
 
 
 class OperationFilterKgraphContinuousKedgeAttribute(BaseOperation):
-    id: constant("filter_kgraph_continuous_kedge_attribute")
+    id: Literal["filter_kgraph_continuous_kedge_attribute"]
     parameters: FilterKgraphContinuousKedgeAttributeParameters
-
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class FilterKgraphDiscreteKedgeAttributeParameters(BaseModel):
     edge_attribute: str
-    remove_value: Any
-    qedge_keys: Optional[HashableSequence[str]]
-    qnode_keys: HashableSequence[str] = []
+    remove_value: Any = None
+    qedge_keys: Optional[HashableSequence[str]] = None
+    qnode_keys: HashableSequence[str] = Field(
+        default_factory=lambda: HashableSequence[str]()
+    )
 
 
 class OperationFilterKgraphDiscreteKedgeAttribute(BaseOperation):
-    id: constant("filter_kgraph_discrete_kedge_attribute")
+    id: Literal["filter_kgraph_discrete_kedge_attribute"]
     parameters: FilterKgraphDiscreteKedgeAttributeParameters
-
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class FilterKgraphDiscreteKnodeAttributeParameters(BaseModel):
     node_attribute: str
-    remove_value: Any
-    qnode_keys: Optional[HashableSequence[str]]
+    remove_value: Any = None
+    qnode_keys: Optional[HashableSequence[str]] = None
 
 
 class OperationFilterKgraphDiscreteKnodeAttribute(BaseOperation):
-    id: constant("filter_kgraph_discrete_knode_attribute")
+    id: Literal["filter_kgraph_discrete_knode_attribute"]
     parameters: FilterKgraphDiscreteKnodeAttributeParameters
-
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class OperationFilterKgraphOrphans(BaseOperation):
-    id: constant("filter_kgraph_orphans")
-    parameters: Optional[Any]
-
-    class Config:
-        extra = "forbid"
+    id: Literal["filter_kgraph_orphans"]
+    parameters: Optional[Any] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class TopOrBottomEnum(str, Enum):
@@ -240,26 +197,28 @@ class TopOrBottomEnum(str, Enum):
 
 class FilterKgraphTopNParameters(BaseModel):
     edge_attribute: str
-    max_edges: conint(le=0) = 50
+    max_edges: Annotated[int, Field(le=0)] = 50
     remove_top_or_bottom: TopOrBottomEnum = TopOrBottomEnum.top
-    qedge_keys: Optional[HashableSequence[str]]
-    qnode_keys: HashableSequence[str] = []
+    qedge_keys: Optional[HashableSequence[str]] = None
+    qnode_keys: HashableSequence[str] = Field(
+        default_factory=lambda: HashableSequence[str]()
+    )
 
 
 class FilterKgraphPercentileParameters(BaseModel):
     edge_attribute: str
-    threshold: confloat(ge=0, le=100) = 95
+    threshold: Annotated[float, Field(ge=0, le=100)] = 95
     remove_above_or_below: AboveOrBelowEnum = AboveOrBelowEnum.below
-    qedge_keys: Optional[HashableSequence[str]]
-    qnode_keys: HashableSequence[str] = []
+    qedge_keys: Optional[HashableSequence[str]] = None
+    qnode_keys: HashableSequence[str] = Field(
+        default_factory=lambda: HashableSequence[str]()
+    )
 
 
 class OperationFilterKgraphPercentile(BaseOperation):
-    id: constant("filter_kgraph_percentile")
+    id: Literal["filter_kgraph_percentile"]
     parameters: FilterKgraphPercentileParameters
-
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class PlusOrMinusEnum(str, Enum):
@@ -272,50 +231,42 @@ class PlusOrMinusEnum(str, Enum):
 class FilterKgraphStdDevParameters(BaseModel):
     edge_attribute: str
     plus_or_minus_std_dev: PlusOrMinusEnum = PlusOrMinusEnum.plus
-    num_sigma: confloat(ge=0) = 1
+    num_sigma: Annotated[float, Field(ge=0)] = 1
     remove_above_or_below: AboveOrBelowEnum = AboveOrBelowEnum.below
-    qedge_keys: Optional[HashableSequence[str]]
-    qnode_keys: HashableSequence[str] = []
+    qedge_keys: Optional[HashableSequence[str]] = None
+    qnode_keys: HashableSequence[str] = Field(
+        default_factory=lambda: HashableSequence[str]()
+    )
 
 
 class OperationFilterKgraphStdDev(BaseOperation):
-    id: constant("filter_kgraph_std_dev")
+    id: Literal["filter_kgraph_std_dev"]
     parameters: FilterKgraphStdDevParameters
-
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class OperationFilterKgraphTopN(BaseOperation):
-    id: constant("filter_kgraph_top_n")
+    id: Literal["filter_kgraph_top_n"]
     parameters: FilterKgraphTopNParameters
-
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class OperationLookup(BaseOperation):
-    id: constant("lookup")
-    parameters: Optional[Any]
-
-    class Config:
-        extra = "forbid"
+    id: Literal["lookup"]
+    parameters: Optional[Any] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class OperationLookupAndScore(BaseOperation):
-    id: constant("lookup_and_score")
-    parameters: Optional[Any]
-
-    class Config:
-        extra = "forbid"
+    id: Literal["lookup_and_score"]
+    parameters: Optional[Any] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class OperationOverlay(BaseOperation):
-    id: constant("overlay")
-    parameters: Optional[Any]
-
-    class Config:
-        extra = "forbid"
+    id: Literal["overlay"]
+    parameters: Optional[Any] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class OverlayComputeJaccardParameters(BaseModel):
@@ -325,11 +276,9 @@ class OverlayComputeJaccardParameters(BaseModel):
 
 
 class OperationOverlayComputeJaccard(BaseOperation):
-    id: constant("overlay_compute_jaccard")
+    id: Literal["overlay_compute_jaccard"]
     parameters: OverlayComputeJaccardParameters
-
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class OverlayComputeNgdParameters(BaseModel):
@@ -338,58 +287,46 @@ class OverlayComputeNgdParameters(BaseModel):
 
 
 class OperationOverlayComputeNgd(BaseOperation):
-    id: constant("overlay_compute_ngd")
+    id: Literal["overlay_compute_ngd"]
     parameters: OverlayComputeNgdParameters
-
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class OperationOverlayConnectKnodes(BaseOperation):
-    id: constant("overlay_connect_knodes")
-    parameters: Optional[Any]
-
-    class Config:
-        extra = "forbid"
+    id: Literal["overlay_connect_knodes"]
+    parameters: Optional[Any] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class OverlayFisherExactTestParameters(BaseModel):
     subject_qnode_key: str
     object_qnode_key: str
     virtual_relation_label: str
-    rel_edge_key: Optional[str]
+    rel_edge_key: Optional[str] = None
 
 
 class OperationOverlayFisherExactTest(BaseOperation):
-    id: constant("overlay_fisher_exact_test")
+    id: Literal["overlay_fisher_exact_test"]
     parameters: OverlayFisherExactTestParameters
-
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class OperationRestate(BaseOperation):
-    id: constant("restate")
-    parameters: Optional[Any]
-
-    class Config:
-        extra = "forbid"
+    id: Literal["restate"]
+    parameters: Optional[Any] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class OperationScore(BaseOperation):
-    id: constant("score")
-    parameters: Optional[Any]
-
-    class Config:
-        extra = "forbid"
+    id: Literal["score"]
+    parameters: Optional[Any] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class OperationSortResults(BaseOperation):
-    id: constant("sort_results")
-    parameters: Optional[Any]
-
-    class Config:
-        extra = "forbid"
+    id: Literal["sort_results"]
+    parameters: Optional[Any] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class AscOrDescEnum(str, Enum):
@@ -402,29 +339,25 @@ class AscOrDescEnum(str, Enum):
 class SortResultsEdgeAttributeParameters(BaseModel):
     edge_attribute: str
     ascending_or_descending: AscOrDescEnum
-    qedge_keys: Optional[HashableSequence[str]]
+    qedge_keys: Optional[HashableSequence[str]] = None
 
 
 class OperationSortResultsEdgeAttribute(BaseOperation):
-    id: constant("sort_results_edge_attribute")
+    id: Literal["sort_results_edge_attribute"]
     parameters: SortResultsEdgeAttributeParameters
-
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class SortResultsNodeAttributeParameters(BaseModel):
     node_attribute: str
     ascending_or_descending: AscOrDescEnum
-    qnode_keys: Optional[HashableSequence[str]]
+    qnode_keys: Optional[HashableSequence[str]] = None
 
 
 class OperationSortResultsNodeAttribute(BaseOperation):
-    id: constant("sort_results_node_attribute")
+    id: Literal["sort_results_node_attribute"]
     parameters: SortResultsNodeAttributeParameters
-
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class SortResultsScoreParameters(BaseModel):
@@ -432,11 +365,9 @@ class SortResultsScoreParameters(BaseModel):
 
 
 class OperationSortResultsScore(BaseOperation):
-    id: constant("sort_results_score")
+    id: Literal["sort_results_score"]
     parameters: SortResultsScoreParameters
-
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 operations = [
@@ -472,9 +403,8 @@ operations = [
     OperationSortResultsScore,
 ]
 
-
-class Operation(BaseModel):
-    __root__: Union[
+Operation = RootModel[
+    Union[
         OperationAnnotate,
         OperationAnnotateEdges,
         OperationAnnotateNodes,
@@ -506,7 +436,7 @@ class Operation(BaseModel):
         OperationSortResultsNodeAttribute,
         OperationSortResultsScore,
     ]
+]
 
 
-class Workflow(BaseModel):
-    __root__: HashableSequence[Operation]
+Workflow = HashableSequence[Operation]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-httpx==0.16.1
-pydantic==1.8.2
-pytest==6.2.2
-pyyaml==5.4.1
+httpx
+pydantic>=2,<3
+pytest
+pyyaml>=6,<7

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ setup(
     long_description_content_type="text/markdown",
     packages=["reasoner_pydantic"],
     include_package_data=True,
-    install_requires=["pydantic>=1.8,<2"],
+    install_requires=["pydantic>=2,<3"],
     zip_safe=False,
     license="MIT",
-    python_requires=">=3.6",
+    python_requires=">=3.9",
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="reasoner-pydantic",
-    version="5.1.1",
+    version="6.0.0",
     author="Abrar Mesbah",
     author_email="amesbah@covar.com",
     url="https://github.com/TranslatorSRI/reasoner-pydantic",

--- a/tests/_test_openapi.py
+++ b/tests/_test_openapi.py
@@ -14,9 +14,7 @@ response = httpx.get(
 reference_schemas = yaml.load(
     response.text,
     Loader=yaml.FullLoader,
-)[
-    "components"
-]["schemas"]
+)["components"]["schemas"]
 
 
 def test_openapi():

--- a/tests/_test_openapi.py
+++ b/tests/_test_openapi.py
@@ -14,7 +14,9 @@ response = httpx.get(
 reference_schemas = yaml.load(
     response.text,
     Loader=yaml.FullLoader,
-)["components"]["schemas"]
+)[
+    "components"
+]["schemas"]
 
 
 def test_openapi():

--- a/tests/_test_operations.py
+++ b/tests/_test_operations.py
@@ -8,8 +8,8 @@ import yaml
 from reasoner_pydantic.workflow import operations
 
 TAG = "v1.3"
-response = httpx.get(f"http://standards.ncats.io/workflow/1.3.2/schema")
-response = httpx.get(f"http://standards.ncats.io/operation/1.3.2/schema")
+response = httpx.get("http://standards.ncats.io/workflow/1.3.2/schema")
+response = httpx.get("http://standards.ncats.io/operation/1.3.2/schema")
 reference_schemas = yaml.load(
     response.text,
     Loader=yaml.FullLoader,

--- a/tests/_test_workflow.py
+++ b/tests/_test_workflow.py
@@ -8,7 +8,7 @@ import yaml
 from reasoner_pydantic.workflow import Workflow
 
 TAG = "v1.3"
-response = httpx.get(f"http://standards.ncats.io/workflow/1.3.2/schema")
+response = httpx.get("http://standards.ncats.io/workflow/1.3.2/schema")
 reference_schema = yaml.load(
     response.text,
     Loader=yaml.FullLoader,

--- a/tests/test_manipulation.py
+++ b/tests/test_manipulation.py
@@ -9,13 +9,14 @@ from reasoner_pydantic import (
     Result,
     NodeBinding,
 )
-from reasoner_pydantic.utils import HashableSet
+from reasoner_pydantic.results import Results
+from reasoner_pydantic.shared import CURIE
 
 
 def test_manipulation():
     """Test manipulation."""
-    request: Query = Query(
-        **{
+    request: Query = Query.model_validate(
+        {
             "message": {
                 "query_graph": {
                     "nodes": {"x": {}},
@@ -26,34 +27,41 @@ def test_manipulation():
     )
 
     message: Message = request.message
-    message.knowledge_graph = KnowledgeGraph(nodes={}, edges={})
-    message.results = HashableSet[Result]()
+    message.knowledge_graph = KnowledgeGraph()
+    message.results = Results()
 
     # get query graph node
+    assert message.query_graph is not None
     assert message.query_graph.nodes, "Query graph contains no nodes!"
     qnode_id = next(iter(message.query_graph.nodes))
 
     # add knowledge graph node
-    knode: Node = Node(categories=["biolink:NamedThing"], attributes=[])
-    knode_id = "foo:bar"
+    knode: Node = Node.model_validate(
+        dict(categories=["biolink:NamedThing"], attributes=[])
+    )
+    knode_id = CURIE("foo:bar")
     message.knowledge_graph.nodes[knode_id] = knode
 
     # add result
-    node_binding: NodeBinding = NodeBinding(id=knode_id, attributes=[])
-    result: Result = Result(
-        node_bindings={qnode_id: [node_binding]},
-        analyses=[],
-        foo="bar",
+    node_binding: NodeBinding = NodeBinding.model_validate(
+        dict(id=knode_id, attributes=[])
+    )
+    result: Result = Result.model_validate(
+        dict(
+            node_bindings={qnode_id: [node_binding]},
+            analyses=[],
+            foo="bar",
+        )
     )
     message.results.add(result)
 
-    print(message.json())
+    print(message.model_dump_json())
 
 
 def test_singletons():
     """Test that str-valued `categories` works."""
-    qnode = QNode(
-        **{
+    _qnode = QNode.model_validate(
+        {
             "ids": ["MONDO:0005737"],
             "categories": ["biolink:Disease"],
         }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,4 @@
-from typing import Optional
 from pydantic import ValidationError
-from reasoner_pydantic.base_model import BaseModel
 from reasoner_pydantic.shared import Attribute, BiolinkEntity
 from reasoner_pydantic import Message, QNode, QEdge, QueryGraph, Result, Response
 
@@ -508,6 +506,6 @@ def test_invalid_pathfinder_query():
     """
 
     try:
-        message = Message.model_validate(INVALID_PATHFINDER_QUERY)
+        _ = Message.model_validate(INVALID_PATHFINDER_QUERY)
     except Exception as e:
         assert isinstance(e, ValidationError)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -31,9 +31,9 @@ EXAMPLE_RESULT = {
 def test_result_hashable():
     """Check that we can hash a result with extra properties"""
 
-    result_obj = Result.parse_obj(EXAMPLE_RESULT)
-    result_dict = result_obj.dict()
+    result_obj = Result.model_validate(EXAMPLE_RESULT)
+    result_dict = result_obj.model_dump()
 
     assert len(result_dict["raw_data"]) == 1
-    assert type(result_obj.raw_data) == HashableSequence
+    assert type(result_obj.raw_data) is HashableSequence
     assert result_obj.raw_data[0] == "test"

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -111,7 +111,7 @@ query2 = {
 def test_workflow():
     """Test construction of a Query with a workflow."""
     query_obj = Query(**query)
-    query_dict = query_obj.dict()
+    query_dict = query_obj.model_dump()
     assert "runner_parameters" in query_dict["workflow"][0].keys()
     assert "parameters" in query_dict["workflow"][0].keys()
     assert "allowlist" in query_dict["workflow"][0]["runner_parameters"].keys()
@@ -122,5 +122,5 @@ def test_workflow():
 
 def test_workflow2():
     query_obj = Query(**query)
-    query_dict = query_obj.dict()
+    query_dict = query_obj.model_dump()
     assert "parameters" in query_dict["workflow"][0].keys()


### PR DESCRIPTION
This PR upgrades dependencies to bring reasoner-pydantic to pydantic v2. Changes:

- Python minimum version bumped to 3.9
- Pydantic minimum version bumped to 2
  - `parse_obj()` is replaced by `model_validate()`
  - `Model.dict()` is replaced by `model_dump()`
  - Validation now occurs by default on model construction, this can be avoided using `model_construct()` (not recommended)
  - Normalization on model creation now requires a validation context to disable (see `docs/NORMALIZE.md`)
  - LogLevel is now directly an enum and uses matching case (e.g. `LogLevel.INFO`)
- Hashing is now deterministic without users having to set `PYTHONHASHSEED`
- Minor changes to bring models in line with TRAPI 1.5
